### PR TITLE
Bolty.Error.message/1 prefers bolt.message 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ __pycache__
 
 # agent related
 .agent-notes/
+.claude

--- a/lib/bolty/bolt_protocol/message/pull_message.ex
+++ b/lib/bolty/bolt_protocol/message/pull_message.ex
@@ -55,6 +55,9 @@ defmodule Bolty.BoltProtocol.Message.PullMessage do
     end
   end
 
+  def format_error(:unsupported_message_version), do: "PULL message version not supported"
+  def format_error(_), do: "unknown error from PULL response"
+
   defp get_extra_parameters(extra_parameters) do
     %{
       n: Map.get(extra_parameters, :n, -1),

--- a/lib/bolty/error.ex
+++ b/lib/bolty/error.ex
@@ -44,8 +44,17 @@ defmodule Bolty.Error do
 
   """
   @spec message(t()) :: String.t()
-  def message(%__MODULE__{code: code, module: module}) do
-    module.format_error(code)
+  def message(%__MODULE__{code: code, module: module, bolt: bolt}) do
+    cond do
+      is_map(bolt) and is_binary(bolt[:message]) ->
+        bolt[:message]
+
+      is_atom(module) and Code.ensure_loaded?(module) and function_exported?(module, :format_error, 1) ->
+        module.format_error(code)
+
+      true ->
+        "#{inspect(module)} error: #{inspect(code)}"
+    end
   end
 
   @doc """

--- a/test/bolty/error_test.exs
+++ b/test/bolty/error_test.exs
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Bolty.ErrorTest do
+  use ExUnit.Case, async: true
+
+  alias Bolty.Error
+
+  describe "Error.message/1" do
+    @tag :core
+    test "returns bolt.message when present" do
+      error =
+        Error.wrap(Bolty.BoltProtocol.Message.PullMessage, %{
+          code: "Neo.ClientError.Statement.EntityNotFound",
+          message: "Unable to load NODE with id 42"
+        })
+
+      assert Exception.message(error) == "Unable to load NODE with id 42"
+    end
+
+    @tag :core
+    test "falls back to module.format_error/1 when bolt.message is absent" do
+      error = Error.wrap(Bolty.BoltProtocol.Message.PullMessage, :unsupported_message_version)
+      assert Exception.message(error) == "PULL message version not supported"
+    end
+
+    @tag :core
+    test "falls back to safe string when module has no format_error/1 and bolt is nil" do
+      error = %Error{module: Bolty.Client, code: :timeout}
+      assert Exception.message(error) == "Bolty.Client error: :timeout"
+    end
+
+    @tag :core
+    test "falls back to safe string when module is nil" do
+      error = %Error{code: :unknown}
+      assert Exception.message(error) == "nil error: :unknown"
+    end
+  end
+
+  describe "PullMessage.format_error/1" do
+    @tag :core
+    test "formats :unsupported_message_version" do
+      alias Bolty.BoltProtocol.Message.PullMessage
+      assert PullMessage.format_error(:unsupported_message_version) == "PULL message version not supported"
+    end
+
+    @tag :core
+    test "formats unknown codes with a fallback" do
+      alias Bolty.BoltProtocol.Message.PullMessage
+      assert is_binary(PullMessage.format_error(:unknown))
+      assert is_binary(PullMessage.format_error(:anything_else))
+    end
+  end
+end


### PR DESCRIPTION
Bolty.Error.message/1 prefers bolt.message (the authoritative Neo4j error text) over module.format_error/1, and guards the fallback with Code.ensure_loaded?/function_exported? to avoid a secondary UndefinedFunctionError crash. Adds PullMessage.format_error/1 and unit tests.