### PR TITLE
feat: document :versions as first-class config; deprecate BOLT_VERSIONS

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ SPDX-License-Identifier: Apache-2.0
 
 `Bolty` is a reluctant fork of the the 'Boltx' Elixir driver for [Neo4j](https://neo4j.com/developer/graph-database/)/Bolt Protocol.
 
-- Supports Neo4j versions: 3.0.x/3.1.x/3.2.x/3.4.x/3.5.x/4.x/5.9 -5.13.0
-- Supports Bolt version: 1.0/2.0/3.0/4.x/5.0/5.1/5.2/5.3/5.4
+- Supports Neo4j 5.26.26 LTS and compatible servers (Memgraph 2.13+)
+- Supports Bolt versions: 5.0/5.1/5.2/5.3/5.4/5.6/5.7/5.8
 - Supports transactions, prepared queries, streaming, pooling and more via DBConnection
 - Automatic decoding and encoding of Elixir values
 
@@ -53,6 +53,12 @@ opts = [
     max_overflow: 3,
     prefix: :default
 ]
+
+# Pin to a specific Bolt version:
+opts = [versions: [5.4]] ++ opts
+
+# Offer multiple versions as ranges (handshake has 4 slots — ranges cover more):
+opts = [versions: [{5, 6..8}, {5, 0..4}]] ++ opts
 
 iex> {:ok, conn} = Bolty.start_link(opts)
 {:ok, #PID<0.237.0>}
@@ -166,7 +172,7 @@ As certain versions of Bolt may be compatible with specific functionalities whil
 
 By default, all tags are disabled except the `:core` tag. To enable the tags, it is necessary to configure the following environment variables:
 
-- `BOLT_VERSIONS`: This variable is used for Bolt version configuration but is also useful for testing. You can specify a version, for example, BOLT_VERSIONS="1.0".
+- `BOLT_VERSIONS`: **Deprecated** — use the `:versions` connection option instead. Still supported as a testing escape hatch (e.g. `BOLT_VERSIONS=5.4 mix test`), but will emit a warning at runtime.
 - `BOLT_TCP_PORT`:  You can configure the port with the environment variable (BOLT_TCP_PORT=7688).
 
 #### Help script

--- a/lib/bolty/client.ex
+++ b/lib/bolty/client.ex
@@ -137,6 +137,12 @@ defmodule Bolty.Client do
                 Versions.latest_versions()
 
               env_versions ->
+                require Logger
+
+                Logger.warning(
+                  "BOLT_VERSIONS env var is deprecated — set :versions in your connection config instead"
+                )
+
                 env_versions
                 |> String.split(",")
                 |> Enum.map(&Converters.to_float/1)

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -90,7 +90,7 @@ Canonical option names (what `Bolty.Client.Config.new/1` actually reads):
 | `:port` | Port | `BOLT_TCP_PORT` env → `7687` |
 | `:scheme` | One of the schemes below | `"bolt+s"` |
 | `:auth` | `[username: ..., password: ...]` | required |
-| `:versions` | Bolt versions to negotiate (e.g. `[4.4]` to prevent Bolt 5) | server-driven negotiation |
+| `:versions` | Bolt versions to negotiate. Accepts floats (`[5.4]`) or range tuples (`[{5, 6..8}, {5, 0..4}]`). Range tuples are preferred — the handshake has only 4 slots and ranges cover more versions per slot. Omit to use `Versions.latest_versions()` (all supported versions, auto-rangeified). `BOLT_VERSIONS` env var is **deprecated** in favour of this option. | `Versions.latest_versions()` |
 | `:user_agent` | Client identity string | `"bolty/<version>"` |
 | `:notifications_minimum_severity` | Bolt 5.2+ | `nil` |
 | `:notifications_disabled_categories` | Bolt 5.2–5.5 | `nil` |


### PR DESCRIPTION
- Add Logger.warning when BOLT_VERSIONS env var is used at runtime, directing users to :versions in connection config instead
- Document :versions in README with float and range tuple examples; note that range tuples are preferred since the handshake has only 4 slots (important on Nerves where env vars are inconvenient)
- Mark BOLT_VERSIONS as deprecated in README testing section
- Expand :versions row in usage-rules.md options table with format details and deprecation note

Closes #23