### PR TITLE
feat: Vector type pack/unpack for Bolt 6.0 (issue #13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,8 @@ iex> Bolty.connection_info(conn)
   policy: %Bolty.Policy{
     datetime: :evolved,
     notifications_field: :notifications_disabled_classifications,
-    gql_errors: true
+    gql_errors: true,
+    vectors: false
   }
 }
 ```
@@ -170,6 +171,7 @@ iex> Bolty.connection_info(conn)
 | Notification filter field | `notifications_disabled_categories` | `notifications_disabled_classifications` | `notifications_disabled_classifications` | `notifications_disabled_classifications` |
 | GQL-compliant errors | No — `code`/`message` keys | No | Yes — `neo4j_code`/`description` keys | Yes |
 | Auth handshake | In HELLO (Bolt 5.0 only) | LOGON | LOGON | LOGON |
+| Vector type | No | No | No | Yes |
 
 The `policy` struct is the single source of truth for version-driven behaviour inside the driver. User code should not need to branch on `bolt_version` directly — check `connection_info/1` if you need to gate application-level features on negotiated capabilities.
 
@@ -192,6 +194,28 @@ opts = [versions: [{5, 6..8}, {5, 0..4}]] ++ opts
 ```
 
 The handshake has four slots; range tuples let you cover a span of minor versions in a single slot. If the server cannot satisfy the offered range(s) the connection will fail with a version-negotiation error rather than silently falling back to an unsupported version.
+
+## Vector embeddings (Bolt 6.0+)
+
+`Bolty.Types.Vector` represents a typed list of floating-point values for embedding and similarity search. It is available on connections negotiated at Bolt 6.0 (Neo4j 2026.05+). Attempting to send a `Vector` over an older connection raises `Bolty.Error` with code `:vector_requires_bolt_6`.
+
+```elixir
+alias Bolty.Types.Vector
+
+# Ensure a Bolt 6.0 connection
+{:ok, conn} = Bolty.start_link([versions: [6.0]] ++ opts)
+
+embedding = Vector.new(:float32, [0.1, 0.2, 0.3])
+
+# Pass as a parameter — round-trips the value over the wire:
+[%{"v" => result}] = Bolty.query!(conn, "RETURN $v AS v", %{v: embedding})
+
+# Storing vectors as node properties requires Neo4j Enterprise Edition.
+```
+
+Supported element types:
+- `:float32` — IEEE-754 single precision (4 bytes per element)
+- `:float64` — IEEE-754 double precision (8 bytes per element)
 
 ## Contributing
 

--- a/lib/bolty/pack_stream/markers.ex
+++ b/lib/bolty/pack_stream/markers.ex
@@ -107,6 +107,18 @@ defmodule Bolty.PackStream.Markers do
       # Point 3D
       @point3d_signature 0x59
       @point3d_struct_size 4
+
+      # Bytes
+      @bytes8_marker 0xCC
+      @bytes16_marker 0xCD
+      @bytes32_marker 0xCE
+
+      # Vector (Bolt 6.0+)
+      @vector_signature 0x56
+      @vector_struct_size 2
+      @vector_float32_marker 0xC6
+      # float64 shares the PackStream float marker value (0xC1)
+      @vector_float64_marker 0xC1
     end
   end
 end

--- a/lib/bolty/pack_stream/packer.ex
+++ b/lib/bolty/pack_stream/packer.ex
@@ -336,6 +336,12 @@ end
 defimpl Bolty.PackStream.Packer, for: Bolty.Types.Vector do
   use Bolty.PackStream.Markers
 
+  alias Bolty.Policy
+
+  def pack(%Bolty.Types.Vector{}, %Policy{vectors: false}) do
+    throw(Bolty.Error.wrap(__MODULE__, :vector_requires_bolt_6))
+  end
+
   def pack(%Bolty.Types.Vector{type: :float32, data: values}, _policy) do
     binary = for v <- values, into: <<>>, do: <<v::big-float-size(32)>>
 

--- a/lib/bolty/pack_stream/packer.ex
+++ b/lib/bolty/pack_stream/packer.ex
@@ -333,6 +333,40 @@ defimpl Bolty.PackStream.Packer, for: Bolty.Types.Point do
   end
 end
 
+defimpl Bolty.PackStream.Packer, for: Bolty.Types.Vector do
+  use Bolty.PackStream.Markers
+
+  def pack(%Bolty.Types.Vector{type: :float32, data: values}, _policy) do
+    binary = for v <- values, into: <<>>, do: <<v::big-float-size(32)>>
+
+    [
+      <<@tiny_struct_marker::4, @vector_struct_size::4, @vector_signature>>,
+      pack_bytes(<<@vector_float32_marker>>),
+      pack_bytes(binary)
+    ]
+  end
+
+  def pack(%Bolty.Types.Vector{type: :float64, data: values}, _policy) do
+    binary = for v <- values, into: <<>>, do: <<v::big-float-size(64)>>
+
+    [
+      <<@tiny_struct_marker::4, @vector_struct_size::4, @vector_signature>>,
+      pack_bytes(<<@vector_float64_marker>>),
+      pack_bytes(binary)
+    ]
+  end
+
+  defp pack_bytes(bin) do
+    size = byte_size(bin)
+
+    cond do
+      size <= 255 -> [<<@bytes8_marker, size>>, bin]
+      size <= 65_535 -> [<<@bytes16_marker, size::16>>, bin]
+      true -> [<<@bytes32_marker, size::32>>, bin]
+    end
+  end
+end
+
 defimpl Bolty.PackStream.Packer, for: Any do
   defmacro __deriving__(module, struct, options) do
     deriving(module, struct, options)

--- a/lib/bolty/pack_stream/unpacker.ex
+++ b/lib/bolty/pack_stream/unpacker.ex
@@ -10,6 +10,7 @@ defmodule Bolty.PackStream.Unpacker do
     TimeWithTZOffset,
     DateTimeWithTZOffset,
     Point,
+    Vector,
     Relationship,
     UnboundRelationship,
     Node,
@@ -52,6 +53,19 @@ defmodule Bolty.PackStream.Unpacker do
 
   def unpack(<<@bitstring32_marker, str_length::32, rest::binary>>) do
     decode_string(rest, str_length)
+  end
+
+  # Bytes
+  def unpack(<<@bytes8_marker, size::8, data::binary-size(size), rest::binary>>) do
+    [data | unpack(rest)]
+  end
+
+  def unpack(<<@bytes16_marker, size::16, data::binary-size(size), rest::binary>>) do
+    [data | unpack(rest)]
+  end
+
+  def unpack(<<@bytes32_marker, size::32, data::binary-size(size), rest::binary>>) do
+    [data | unpack(rest)]
   end
 
   # Lists
@@ -310,6 +324,12 @@ defmodule Bolty.PackStream.Unpacker do
     [point | rest]
   end
 
+  # Vector (Bolt 6.0+)
+  def unpack({@vector_signature, struct, @vector_struct_size}) do
+    {[type_marker, data], rest} = decode_struct(struct, @vector_struct_size)
+    [decode_vector(type_marker, data) | rest]
+  end
+
   # Private
   @spec decode_string(binary(), integer()) :: list()
   defp decode_string(bytes, str_length) do
@@ -329,6 +349,17 @@ defmodule Bolty.PackStream.Unpacker do
     {map, rest} = map |> unpack() |> Enum.split(entries * 2)
 
     [to_map(map) | rest]
+  end
+
+  @spec decode_vector(binary(), binary()) :: Vector.t()
+  defp decode_vector(<<@vector_float32_marker>>, data) do
+    values = for <<v::big-float-size(32) <- data>>, do: v
+    %Vector{type: :float32, data: values}
+  end
+
+  defp decode_vector(<<@vector_float64_marker>>, data) do
+    values = for <<v::big-float-size(64) <- data>>, do: v
+    %Vector{type: :float64, data: values}
   end
 
   @spec decode_struct(binary(), integer()) :: {list(), list()}

--- a/lib/bolty/policy.ex
+++ b/lib/bolty/policy.ex
@@ -39,11 +39,13 @@ defmodule Bolty.Policy do
   @type t :: %__MODULE__{
           datetime: datetime(),
           notifications_field: notifications_field(),
-          gql_errors: boolean()
+          gql_errors: boolean(),
+          vectors: boolean()
         }
 
   # defaults reflect the lowest supported Bolt version (5.0)
   defstruct datetime: :evolved,
             notifications_field: :notifications_disabled_categories,
-            gql_errors: false
+            gql_errors: false,
+            vectors: false
 end

--- a/lib/bolty/policy/resolver.ex
+++ b/lib/bolty/policy/resolver.ex
@@ -29,8 +29,7 @@ defmodule Bolty.Policy.Resolver do
     |> put_datetime(bolt_version, server_version)
     |> put_notifications_field(bolt_version, server_version)
     |> put_gql_errors(bolt_version, server_version)
-
-    # |> put_vectors(bolt_version, server_version)  # issue #13
+    |> put_vectors(bolt_version, server_version)
   end
 
   # Bolt 5.x uses evolved DateTime struct tags (0x49/0x69).
@@ -59,4 +58,12 @@ defmodule Bolty.Policy.Resolver do
   end
 
   defp put_gql_errors(policy, _bolt_version, _server_version), do: policy
+
+  # Bolt 6.0 introduced the Vector PackStream struct (signature 0x56).
+  defp put_vectors(policy, bolt_version, _server_version)
+       when is_float(bolt_version) and bolt_version >= 6.0 do
+    %{policy | vectors: true}
+  end
+
+  defp put_vectors(policy, _bolt_version, _server_version), do: policy
 end

--- a/lib/bolty/types.ex
+++ b/lib/bolty/types.ex
@@ -29,6 +29,9 @@ defmodule Bolty.Types do
   For spatial types, you only need Point struct as it covers:
   - 2D point (cartesian or geographic)
   - 3D point (cartesian or geographic)
+
+  Bolt 6.0 (Neo4j 2026.05+) adds:
+  - Vector — a typed list of floating-point values used for embedding/similarity search
   """
 
   alias Bolty.TypesHelper
@@ -272,8 +275,8 @@ defmodule Bolty.Types do
     @moduledoc """
     A typed vector of floating-point values, as introduced in Bolt 6.0 (Neo4j 2026.05+).
 
-    Use `%Vector{}` as a query parameter to store embeddings, or receive one back
-    when querying a node property of type VECTOR.
+    Requires a connection negotiated at Bolt 6.0 or later — packing a Vector over
+    an older connection raises `Bolty.Error` with code `:vector_requires_bolt_6`.
 
     ## Fields
     - `type` — element precision: `:float32` (IEEE-754 single) or `:float64` (IEEE-754 double)
@@ -283,8 +286,12 @@ defmodule Bolty.Types do
 
         alias Bolty.Types.Vector
 
+        # Pass a vector as a query parameter (works on Community Edition):
         embedding = Vector.new(:float32, [0.1, 0.2, 0.3])
-        Bolty.query!(conn, "CREATE (n:Item {embedding: $v}) RETURN n", %{v: embedding})
+        [%{"v" => result}] = Bolty.query!(conn, "RETURN $v AS v", %{v: embedding})
+
+        # Storing vectors as node properties requires Neo4j Enterprise Edition:
+        Bolty.query!(conn, "CREATE (n:Item {embedding: $v})", %{v: embedding})
     """
 
     @type element_type :: :float32 | :float64

--- a/lib/bolty/types.ex
+++ b/lib/bolty/types.ex
@@ -268,6 +268,40 @@ defmodule Bolty.Types do
     end
   end
 
+  defmodule Vector do
+    @moduledoc """
+    A typed vector of floating-point values, as introduced in Bolt 6.0 (Neo4j 2026.05+).
+
+    Use `%Vector{}` as a query parameter to store embeddings, or receive one back
+    when querying a node property of type VECTOR.
+
+    ## Fields
+    - `type` — element precision: `:float32` (IEEE-754 single) or `:float64` (IEEE-754 double)
+    - `data` — list of float values
+
+    ## Example
+
+        alias Bolty.Types.Vector
+
+        embedding = Vector.new(:float32, [0.1, 0.2, 0.3])
+        Bolty.query!(conn, "CREATE (n:Item {embedding: $v}) RETURN n", %{v: embedding})
+    """
+
+    @type element_type :: :float32 | :float64
+
+    @type t :: %__MODULE__{
+            type: element_type(),
+            data: [float()]
+          }
+
+    defstruct [:type, :data]
+
+    @spec new(:float32 | :float64, [float()]) :: t()
+    def new(type, data) when type in [:float32, :float64] and is_list(data) do
+      %__MODULE__{type: type, data: data}
+    end
+  end
+
   defmodule Point do
     @moduledoc """
     Manage spatial data introduced in Bolt V2

--- a/test/bolty/pack_stream_test.exs
+++ b/test/bolty/pack_stream_test.exs
@@ -10,8 +10,8 @@ defmodule Bolty.PackStreamTest do
   alias Bolty.TypesHelper
   alias Bolty.TestDerivationStruct
 
-
   @evolved %Policy{datetime: :evolved}
+  @bolt_6 %Policy{datetime: :evolved, vectors: true}
 
   defmodule TestStruct do
     defstruct foo: "bar"
@@ -772,7 +772,7 @@ defmodule Bolty.PackStreamTest do
     alias Bolty.Types.Vector
 
     test "pack float32 vector" do
-      packed = PackStream.pack!(Vector.new(:float32, [1.0, 2.0, 3.0]))
+      packed = PackStream.pack!(Vector.new(:float32, [1.0, 2.0, 3.0]), @bolt_6)
 
       assert <<
                # tiny struct, 2 fields, sig 0x56
@@ -788,7 +788,7 @@ defmodule Bolty.PackStreamTest do
     end
 
     test "pack float64 vector" do
-      packed = PackStream.pack!(Vector.new(:float64, [1.0, 2.0]))
+      packed = PackStream.pack!(Vector.new(:float64, [1.0, 2.0]), @bolt_6)
 
       assert <<
                # tiny struct, 2 fields, sig 0x56
@@ -804,7 +804,7 @@ defmodule Bolty.PackStreamTest do
 
     test "float32 round-trip" do
       vector = Vector.new(:float32, [0.0, 1.0, -1.0, 100.0])
-      [result] = PackStream.pack!(vector) |> PackStream.unpack!()
+      [result] = PackStream.pack!(vector, @bolt_6) |> PackStream.unpack!()
 
       assert result.type == :float32
       assert length(result.data) == 4
@@ -814,7 +814,7 @@ defmodule Bolty.PackStreamTest do
 
     test "float64 round-trip" do
       vector = Vector.new(:float64, [0.0, 1.0, -1.0, 1.0e100])
-      [result] = PackStream.pack!(vector) |> PackStream.unpack!()
+      [result] = PackStream.pack!(vector, @bolt_6) |> PackStream.unpack!()
 
       assert result.type == :float64
       assert result.data == [0.0, 1.0, -1.0, 1.0e100]
@@ -829,6 +829,12 @@ defmodule Bolty.PackStreamTest do
                   <<0xCC, 0x01, 0xC6, 0xCC, 0x08, 0x3F, 0x80, 0x00, 0x00, 0x40, 0x00, 0x00,
                     0x00>>, 2}
                )
+    end
+
+    test "packing Vector on a pre-6.0 connection raises :vector_requires_bolt_6" do
+      assert_raise Bolty.Error, fn ->
+        PackStream.pack!(Vector.new(:float32, [1.0, 2.0]), %Policy{vectors: false})
+      end
     end
   end
 end

--- a/test/bolty/pack_stream_test.exs
+++ b/test/bolty/pack_stream_test.exs
@@ -765,4 +765,70 @@ defmodule Bolty.PackStreamTest do
                )
     end
   end
+
+  describe "Vector (Bolt 6.0+):" do
+    @describetag :core
+
+    alias Bolty.Types.Vector
+
+    test "pack float32 vector" do
+      packed = PackStream.pack!(Vector.new(:float32, [1.0, 2.0, 3.0]))
+
+      assert <<
+               # tiny struct, 2 fields, sig 0x56
+               0xB2, 0x56,
+               # type_marker: bytes(1) = 0xC6
+               0xCC, 0x01, 0xC6,
+               # data: bytes(12) — three float32 big-endian values
+               0xCC, 0x0C,
+               0x3F, 0x80, 0x00, 0x00,
+               0x40, 0x00, 0x00, 0x00,
+               0x40, 0x40, 0x00, 0x00
+             >> = packed
+    end
+
+    test "pack float64 vector" do
+      packed = PackStream.pack!(Vector.new(:float64, [1.0, 2.0]))
+
+      assert <<
+               # tiny struct, 2 fields, sig 0x56
+               0xB2, 0x56,
+               # type_marker: bytes(1) = 0xC1
+               0xCC, 0x01, 0xC1,
+               # data: bytes(16) — two float64 big-endian values
+               0xCC, 0x10,
+               0x3F, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+               0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+             >> = packed
+    end
+
+    test "float32 round-trip" do
+      vector = Vector.new(:float32, [0.0, 1.0, -1.0, 100.0])
+      [result] = PackStream.pack!(vector) |> PackStream.unpack!()
+
+      assert result.type == :float32
+      assert length(result.data) == 4
+      # float32 has ~7 decimal digits of precision; these values are exact
+      assert result.data == [0.0, 1.0, -1.0, 100.0]
+    end
+
+    test "float64 round-trip" do
+      vector = Vector.new(:float64, [0.0, 1.0, -1.0, 1.0e100])
+      [result] = PackStream.pack!(vector) |> PackStream.unpack!()
+
+      assert result.type == :float64
+      assert result.data == [0.0, 1.0, -1.0, 1.0e100]
+    end
+
+    test "unpack from raw bytes (struct tuple form)" do
+      # type_marker bytes: <<0xC6>> (float32)
+      # data bytes: 1.0f32, 2.0f32
+      assert [%Vector{type: :float32, data: [1.0, 2.0]}] ==
+               PackStream.unpack!(
+                 {0x56,
+                  <<0xCC, 0x01, 0xC6, 0xCC, 0x08, 0x3F, 0x80, 0x00, 0x00, 0x40, 0x00, 0x00,
+                    0x00>>, 2}
+               )
+    end
+  end
 end

--- a/test/bolty/policy/resolver_test.exs
+++ b/test/bolty/policy/resolver_test.exs
@@ -81,4 +81,16 @@ defmodule Bolty.Policy.ResolverTest do
       assert %Policy{gql_errors: true} = Resolver.resolve(5.8, %{})
     end
   end
+
+  describe "resolve/2 vectors dimension" do
+    @describetag :core
+
+    test "Bolt 5.8 has vectors: false" do
+      assert %Policy{vectors: false} = Resolver.resolve(5.8, %{})
+    end
+
+    test "Bolt 6.0 has vectors: true" do
+      assert %Policy{vectors: true} = Resolver.resolve(6.0, %{})
+    end
+  end
 end

--- a/test/bolty_test.exs
+++ b/test/bolty_test.exs
@@ -5,7 +5,7 @@ defmodule BoltyTest do
   use ExUnit.Case, async: true
 
   alias Bolty.Response
-  alias Bolty.Types.{Point, DateTimeWithTZOffset, TimeWithTZOffset}
+  alias Bolty.Types.{Point, DateTimeWithTZOffset, TimeWithTZOffset, Vector}
 
   alias Bolty.TypesHelper
 
@@ -737,6 +737,36 @@ defmodule BoltyTest do
 
       assert {:ok, %Response{results: [%{"d" => ^expected}]}} =
                Bolty.query(c.conn, query, params)
+    end
+  end
+
+  describe "vector (Bolt 6.0+)" do
+    setup [:connect]
+
+    @tag :bolt_6_x
+    test "float32 vector round-trips over the wire", c do
+      embedding = Vector.new(:float32, [0.1, 0.2, 0.3, 0.4])
+
+      assert {:ok, %Response{results: [%{"v" => result}]}} =
+               Bolty.query(c.conn, "RETURN $v AS v", %{v: embedding})
+
+      assert %Vector{type: :float32} = result
+      assert length(result.data) == 4
+      # float32 has ~7 decimal digits of precision; assert within single-precision epsilon
+      Enum.zip(embedding.data, result.data)
+      |> Enum.each(fn {expected, actual} ->
+        assert_in_delta expected, actual, 1.0e-6
+      end)
+    end
+
+    @tag :bolt_6_x
+    test "float64 vector round-trips over the wire", c do
+      embedding = Vector.new(:float64, [1.0, 2.0, 3.0, 4.0])
+
+      assert {:ok, %Response{results: [%{"v" => result}]}} =
+               Bolty.query(c.conn, "RETURN $v AS v", %{v: embedding})
+
+      assert %Vector{type: :float64, data: [1.0, 2.0, 3.0, 4.0]} = result
     end
   end
 


### PR DESCRIPTION
## Summary

- Implements `Bolty.Types.Vector` — a typed list of floats for embedding/similarity search
- Adds PackStream encoding and decoding of the Vector struct (signature `0x56`, 2 fields: `type_marker` + `data` as Bytes)
- Supports `:float32` (IEEE-754 single) and `:float64` (IEEE-754 double) element types
- Adds the previously-missing Bytes type decoders (`0xCC`/`0xCD`/`0xCE`), a prerequisite for Vector fields
- `Policy` gains a `vectors: boolean()` field set by the resolver for Bolt ≥ 6.0; the packer raises `:vector_requires_bolt_6` on older connections
- Documents the Enterprise Edition requirement for Vector property storage

## Test plan

- [ ] `mix test.matrix` all 10 runs pass (Bolt 5.0–5.8 on 5.26.26 LTS, Bolt 6.0 on 2026.05, full negotiation)
- [ ] Unit tests: 5 pack/unpack tests + 1 version guard test in `pack_stream_test.exs`
- [ ] Integration tests: 2 `@tag :bolt_6_x` tests using `RETURN $v AS v` confirming wire round-trip on Community Edition
- [ ] Resolver tests: 2 new tests for `vectors` policy dimension

## Notes

Vector *property storage* (e.g. `CREATE (n:Item {embedding: $v})`) requires Neo4j Enterprise Edition. The integration tests intentionally use `RETURN $v AS v` to test the wire codec on Community Edition. This is documented in the Vector moduledoc and README.

Closes #13