### PR TITLE
chore: drop Memgraph support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ SPDX-License-Identifier: Apache-2.0
 [![REUSE status](https://api.reuse.software/badge/github.com/diffo-dev/bolty)](https://api.reuse.software/info/github.com/diffo-dev/bolty)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/diffo-dev/bolty)
 
-`Bolty` is a reluctant fork of the the 'Boltx' Elixir driver for [Neo4j](https://neo4j.com/developer/graph-database/)/Bolt Protocol.
+`Bolty` is an Elixir driver for [Neo4j](https://neo4j.com/developer/graph-database/)/Bolt Protocol, forked from `Boltx` and now developed independently.
 
-- Supports Neo4j 5.26.26 LTS, Neo4j 2026.05, and compatible servers (Memgraph 2.13+)
+- Supports Neo4j 5.26.26 LTS and Neo4j 2026.05
 - Supports Bolt versions: 5.0/5.1/5.2/5.3/5.4/5.6/5.7/5.8/6.0
 - Supports transactions, prepared queries, streaming, pooling and more via DBConnection
 - Automatic decoding and encoding of Elixir values
@@ -252,4 +252,4 @@ To simplify test execution, the test-runner.sh script is available. You can find
 
 ## Acknowledgments
 
-Thanks to [Florin Patrascu](https://github.com/florinpatrascu) for [bolt_sips](https://github.com/florinpatrascu/bolt_sips) and[Luis Sagastume](https://github.com/sagastume) for [boltx](https://github.com/sagastume/boltx).
+Thanks to [Florin Patrascu](https://github.com/florinpatrascu) for [bolt_sips](https://github.com/florinpatrascu/bolt_sips) and [Luis Sagastume](https://github.com/sagastume) for [boltx](https://github.com/sagastume/boltx).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,15 +22,3 @@ services:
       - 7690:7687
     environment:
       - NEO4J_AUTH=neo4j/password
-  memgraph-2.13.0:
-    image: "memgraph/memgraph:2.13.0"
-    labels:
-        - "boltVersions=5.0,5.1,5.2"
-        - "database=memgraph"
-    ports:
-      - "7691:7687"
-    environment:
-      MEMGRAPH_USER: "neo4j"
-      MEMGRAPH_PASSWORD: "password"
-    command: ["--also-log-to-stderr=true", "--bolt-server-name-for-init=Neo4j/5.2.0"]
-    entrypoint: ["/usr/lib/memgraph/memgraph", "--log-level=TRACE"]

--- a/lib/bolty/policy/resolver.ex
+++ b/lib/bolty/policy/resolver.ex
@@ -34,7 +34,6 @@ defmodule Bolty.Policy.Resolver do
 
   # Bolt 5.x uses evolved DateTime struct tags (0x49/0x69).
   # Bolt 4.x and below (no longer supported) used :legacy.
-  # Memgraph advertises "Neo4j/5.2.0" but speaks Bolt 5.x — :evolved applies.
   defp put_datetime(policy, bolt_version, _server_version)
        when is_float(bolt_version) and bolt_version >= 5.0 do
     %{policy | datetime: :evolved}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,14 +14,14 @@ The script uses docker-compose.yml file to configure database services and their
 The labels that need to be set on each service are as follows:
 
 - boltVersions: A comma-separated list of Bolt versions (e.g., "1.0,5.2").
-- database: The name of the database that the service uses (e.g., "neo4j" or "memgraph"). Each service should have only one database.
+- database: The name of the database that the service uses (e.g., "neo4j"). Each service should have only one database.
 
 The versions in boltVersions should be floating-point numbers, such as "1.0" instead of "1". These versions match the tags in Elixir tests, for example, @tag bolt_version: "1.0".
 
 To run the script, you can use the following format:
 
 ```shell
-./scripts/test-runner.sh -c "mix test" -b "1.0,5.2" -d "neo4j,memgraph"
+./scripts/test-runner.sh -c "mix test" -b "5.0,5.8" -d "neo4j"
 ```
 
 or

--- a/test/bolty/policy/resolver_test.exs
+++ b/test/bolty/policy/resolver_test.exs
@@ -22,12 +22,6 @@ defmodule Bolty.Policy.ResolverTest do
       assert %Policy{datetime: :evolved} = Resolver.resolve(5.8, %{"server" => "Neo4j/5.26.26"})
     end
 
-    test "Memgraph masquerading as Neo4j/5.2.0 at Bolt 5.2 resolves to :evolved" do
-      # If calibration later shows Memgraph needs :legacy at Bolt 5.x, add a
-      # server_version branch in `put_datetime/3`.
-      assert %Policy{datetime: :evolved} = Resolver.resolve(5.2, %{"server" => "Neo4j/5.2.0"})
-    end
-
     test "missing server metadata does not crash; still decides from bolt_version" do
       assert %Policy{datetime: :evolved} = Resolver.resolve(5.0, %{})
     end

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -9,10 +9,10 @@ SPDX-License-Identifier: Apache-2.0
 
 ## 1. What bolty is
 
-`bolty` is an Elixir driver for [Neo4j](https://neo4j.com/) and other Bolt-speaking graph databases (notably Memgraph). It is a **reluctant fork** of [`boltx`](https://github.com/sagastume/boltx) — kept alive because specific fixes were needed (duration handling, maintenance), not because we wanted a new driver. Treat it as boltx-compatible in spirit; the upstream acknowledgment belongs to Luis Sagastume (`boltx`) and Florin Patrascu (`bolt_sips`).
+`bolty` is an Elixir driver for [Neo4j](https://neo4j.com/), forked from [`boltx`](https://github.com/sagastume/boltx) and now developed independently — the codebases have diverged significantly over the past year. Upstream acknowledgment belongs to Luis Sagastume (`boltx`) and Florin Patrascu (`bolt_sips`).
 
 - **Protocol**: Bolt 5.0 → 5.4, 5.6 → 5.8, with version negotiation at handshake time.
-- **Server compatibility**: Neo4j 5.26.26 LTS (Bolt 5.0–5.4, 5.6–5.8), Memgraph 2.13 (Bolt 5.0–5.2, advertised as Neo4j/5.2.0).
+- **Server compatibility**: Neo4j 5.26.26 LTS (Bolt 5.0–5.4, 5.6–5.8), Neo4j 2026.05 (Bolt 6.0).
 - **Pooling/transactions/prepared queries** via [`DBConnection`](https://hexdocs.pm/db_connection).
 - **Hex package**: `:bolty` (current version in `mix.exs`).
 
@@ -20,7 +20,7 @@ SPDX-License-Identifier: Apache-2.0
 
 **Use bolty when**:
 - You need direct Cypher/Bolt access from Elixir with `DBConnection` pooling.
-- You are speaking to Neo4j or a Bolt-compatible engine (Memgraph).
+- You are speaking to Neo4j.
 - You want to hand-write Cypher and deal in `Bolty.Types.*` structs.
 
 **Do not use bolty when**:
@@ -204,11 +204,11 @@ Local server matrix via `docker-compose.yml`:
 | Service | Image | Ports (host:container) | Bolt versions |
 | --- | --- | --- | --- |
 | `neo4j-5.26.26` | `neo4j:5.26.26-community` | `7690:7687` | 5.0–5.4, 5.6–5.8 |
-| `memgraph-2.13.0` | `memgraph/memgraph:2.13.0` | `7691:7687` | 5.0–5.2 |
+| `neo4j-2026.05` | `neo4j:2026.05.0-community-ubi10` | `7689:7687` | 6.0 |
 
-All use credentials `neo4j / boltyPassword`.
+All use credentials `neo4j / password`.
 
-Test runner orchestrates this via `./scripts/test-runner.sh -c "mix test" -b "1.0,5.2" -d "neo4j,memgraph"`. Requires Docker, docker-compose, `jq`; `bats` for the script's own tests. See `scripts/README.md`.
+Use `mix test.matrix` to run the full version matrix. Requires Docker and docker-compose. See `scripts/README.md`.
 
 ## 13. Development loop
 
@@ -329,7 +329,6 @@ Snapshot from `.agent-notes/issues.json` — re-dump to refresh.
 | [#12](https://github.com/diffo-dev/bolty/issues/12) | reuse compliance | enhancement | Make bolty (and its deps handling) REUSE-compliant. |
 | [#13](https://github.com/diffo-dev/bolty/issues/13) | vector | enhancement | Investigate Neo4j vector / vector-search support. DozerDB caps at Neo4j 5.26.3 so the useful envelope is bounded; may need negotiated Bolt-version behaviour. |
 | [#16](https://github.com/diffo-dev/bolty/issues/16) | boltx-era inheritance cleanup | maintenance | Drop `patch_bolt` dead wiring from `Bolty.Connection`, modernise `config/test.exs` and `.iex.exs` against the current `Bolty.Client.Config.new/1` option names, rewrite `Bolty.Response`'s Spanish docstring in English. Active on branch `16-boltx-related-maintenance`. |
-| &mdash; | memgraph datetime calibration | maintenance | Separate follow-up: run the Europe/Berlin round-trip test against the `memgraph-2.13.0` docker-compose service when a Memgraph instance is available, then either add it as a regression test (if the resolver's default already works) or add a `server_version =~ "Memgraph"` branch in `Bolty.Policy.Resolver.put_datetime/3`. Deferred — no blocker for 0.0.10. |
 
 **Closed (for historical context)**
 


### PR DESCRIPTION
## Summary

Memgraph is BSL-licensed (not open source) and has its own Elixir driver ecosystem. The codebases have diverged enough over the past year that bolty is now a standalone Neo4j driver — maintaining Memgraph compatibility adds noise without benefit.

- Remove `memgraph-2.13.0` from `docker-compose.yml`
- Remove the Memgraph masquerade test and comment from `resolver_test.exs` and `resolver.ex`
- Update `README.md`, `usage-rules.md`, `scripts/README.md` to remove all Memgraph references
- Update the docker services table in `usage-rules.md` to include `neo4j-2026.05`
- Drop "reluctant fork" language — bolty is now developed independently

Closes #15