### PR TITLE
docs: sync capability docs with policy flags; add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,59 @@
+<!--
+SPDX-FileCopyrightText: 2024 bolty contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# AGENTS.md
+
+Notes for whoever picks this up next — human maintainer or coding agent, quite
+possibly neither of the people who wrote these. The detailed reference is
+[`usage-rules.md`](./usage-rules.md); this file is the orientation and the
+hard-won bits that aren't obvious from the code.
+
+## Working agreements
+
+- **Conventional Commits**, always — they drive the changelog (see Releases). Types and sections are listed in `usage-rules.md` §16.
+- **No "Co-Authored-By" trailers**, and **no AI/assistant attribution** anywhere in commits, PRs, or issues. Write them as a maintainer would.
+- **Verify, don't assume.** If a request references an issue, read it (`gh issue view N`). If it leans on "how the other repos do it," check them (e.g. `gh api repos/diffo-dev/ash_neo4j/contents/...`) rather than guessing. When a decision changes committed infrastructure and intent is unclear, ask.
+
+## Releases (git_ops)
+
+bolty uses [`git_ops`](https://hex.pm/packages/git_ops) (configured in `config/dev.exs`), consistent with the other diffo-dev repos. Do **not** hand-edit the version or CHANGELOG.
+
+Typical flow:
+
+1. Feature branch → PR to `dev`. CI must be green.
+2. Merge to `dev`.
+3. `mix git_ops.release` on `dev` — bumps `@version` in `mix.exs`, updates the README dep snippet, writes the `CHANGELOG.md` section, commits and tags `vX.Y.Z`. `feat` → minor, `fix`/etc. → patch (pre-1.0 too).
+4. Push `dev` and the tag; merge `dev` → `main`; `gh release create vX.Y.Z`; then **you** run `mix hex.publish` (needs Hex credentials).
+
+Docs-only fix right after publishing? Within Hex's ~1-hour window you can correct the README, **move the tag** onto the fix, and re-publish the same version (`git tag -f`, `git push -f` the tag). Only `README.md` + `CHANGELOG.md` ship in the package (`mix.exs` `files`), so a fix to `usage-rules.md` / this file does not need a republish.
+
+## CI
+
+Runs on PRs to `dev`/`main` (it once targeted a non-existent `master` and silently never ran — keep an eye on the trigger). Gates: `mix format --check`, `mix compile --warnings-as-errors`, `mix dialyzer` (PLT cached under `priv/plts`), the Bolt-version test matrix (needs Neo4j), and REUSE. **Keep dialyzer at 0 warnings and the compile clean** — that baseline is the point of #50.
+
+Every new source file needs an SPDX header (REUSE check), Apache-2.0.
+
+## Local Neo4j — shared, handle with care
+
+The test databases are **shared across diffo-dev repos** (bolty and ash_neo4j run the same containers). `docker-compose.yml` is aligned with ash_neo4j:
+
+- `neo4j-bolt5` — `neo4j:5.26.27` on **7687** (Bolt 5.x)
+- `neo4j-bolt6` — `neo4j:2026.05` on **7689** (Bolt 6.0)
+- auth `neo4j` / `password`
+
+Do **not** `docker rm` / `docker compose up --remove-orphans` against these — you may break another repo's session. Connect to what's already running. Note the suite's setup runs `MATCH (n) DETACH DELETE n`, so don't point it at a database you care about. Run the version matrix with `mix test.matrix` (`BOLT_6_TCP_PORT=7689` for the Bolt 6 server).
+
+## Policy is the source of truth — and keep its docs in sync
+
+Version- and server-driven behaviour lives in `%Bolty.Policy{}`, resolved once at HELLO by `Bolty.Policy.Resolver` and surfaced read-only via `Bolty.connection_info/1`. Codecs pattern-match policy fields; they never read a version number directly.
+
+When you add or change a Policy flag you **must** update the docs in the same change — we shipped v0.2.0 with the flags but stale docs and had to chase it:
+
+- README → "Negotiated capabilities" (the `connection_info/1` example **and** the capability/flag tables)
+- `usage-rules.md` → §11 (feature matrix) and §14 (policy dimensions)
+
+## Relationship to ash_neo4j
+
+bolty is the Bolt driver beneath [ash_neo4j](https://github.com/diffo-dev/ash_neo4j) (the Ash data layer). Keep tooling and conventions aligned — `git_ops`, the docker-compose ports/creds, commit style. When unsure about a convention, look at what ash_neo4j does.

--- a/README.md
+++ b/README.md
@@ -158,7 +158,10 @@ iex> Bolty.connection_info(conn)
     datetime: :evolved,
     notifications_field: :notifications_disabled_classifications,
     gql_errors: true,
-    vectors: false
+    vectors: false,
+    cypher_5: true,
+    cypher_25: false,
+    dynamic_labels: true
   }
 }
 ```
@@ -174,6 +177,18 @@ iex> Bolty.connection_info(conn)
 | Vector type | No | No | No | Yes |
 
 The `policy` struct is the single source of truth for version-driven behaviour inside the driver. User code should not need to branch on `bolt_version` directly — check `connection_info/1` if you need to gate application-level features on negotiated capabilities.
+
+### Server capability flags
+
+`cypher_5`, `cypher_25` and `dynamic_labels` are derived from the **server** version reported at HELLO (not the negotiated Bolt version), so they capture Cypher-language capabilities that vary by Neo4j release rather than by wire protocol:
+
+| Flag | `true` when | Example feature |
+|---|---|---|
+| `cypher_5` | server speaks `CYPHER 5` (Neo4j ≥ 5.0) — every currently supported server | prefix queries with `CYPHER 5` |
+| `cypher_25` | server supports the `CYPHER 25` selector (Neo4j ≥ 2025.06) | `CYPHER 25` syntax |
+| `dynamic_labels` | dynamic node labels/types (Neo4j ≥ 5.26) — a strict superset of `cypher_25` | `MATCH (n:$($label))` |
+
+So a `5.26.x` server resolves to `dynamic_labels: true, cypher_25: false`, while a `2026.05` server has both `true`. These flags are only meaningful in the policy resolved after HELLO; they default to `false` beforehand.
 
 ### Restricting the negotiated version
 

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -186,9 +186,11 @@ Everything else becomes `:unknown`, with the raw map still available in `error.b
 | Encoding/decoding of graph, temporal, spatial types | ✅ |
 | TLS variants (full / self-signed / off) | ✅ |
 | Notifications opt-out (Bolt 5.2+) | ✅ |
+| Vector type pack/unpack (Bolt 6.0) | ✅ — issue [#13](https://github.com/diffo-dev/bolty/issues/13) |
+| Negotiated capability flags via `connection_info/1` | ✅ — `cypher_5`/`cypher_25`/`dynamic_labels` + wire-level dims (see §14) |
 | Streaming result sets | ❌ |
 | Cluster routing (`neo4j://` autodiscovery) | ❌ |
-| Vector / vector search (indexes, similarity ops) | ❌ — under investigation, issue [#13](https://github.com/diffo-dev/bolty/issues/13) |
+| Vector search (indexes, similarity ops) | ❌ — bolty exposes the type; search belongs to the query layer |
 
 If an agent needs routing or streaming today, that is not bolty's job — surface the gap to Matt rather than working around it silently.
 
@@ -253,13 +255,22 @@ Compliance goals: bolty aims for [REUSE](https://reuse.software/) compliance (li
 
 Version-aware encoding lives in `%Bolty.Policy{}` — an internal struct resolved once at HELLO completion from `(bolt_version, server_version)` via `Bolty.Policy.Resolver`, stashed on both `Bolty.Connection` and `Bolty.Client` state, and threaded through every `pack/2` call as a second argument. Codecs pattern-match on policy fields and never read a version number directly; that is the acceptance criterion for any future dimension.
 
-Policy is **not** user-facing — it's the driver's own distillation of negotiated facts about how Bolt and the server have evolved. Dimensions today:
+Policy is the driver's own distillation of negotiated facts about how Bolt and the server have evolved. It is internal, but surfaced read-only via `Bolty.connection_info/1` so consumers can gate behaviour on a flag instead of parsing version strings. Dimensions today:
 
-- `:datetime` — `:legacy` on Bolt ≤ 4.x (tags 0x46/0x66, body carries local-wall-clock seconds) or `:evolved` on Bolt ≥ 5.0 (tags 0x49/0x69, body carries UTC-instant seconds). Implemented in 0.0.10 to resolve issue [#10](https://github.com/diffo-dev/bolty/issues/10).
+**Wire-level** — derived from the negotiated Bolt version:
 
-When vectors (issue [#13](https://github.com/diffo-dev/bolty/issues/13)) land, add a new dimension to `Bolty.Policy`, extend `Bolty.Policy.Resolver` with a pure `put_vectors/3` clause, and dispatch the relevant codec on it — do **not** bypass the boundary.
+- `:datetime` — `:legacy` on Bolt ≤ 4.x (tags 0x46/0x66, local-wall-clock seconds) or `:evolved` on Bolt ≥ 5.0 (tags 0x49/0x69, UTC-instant seconds). Issue [#10](https://github.com/diffo-dev/bolty/issues/10).
+- `:notifications_field` — HELLO field for disabled notification categories: `:notifications_disabled_categories` (Bolt ≤ 5.5) or `:notifications_disabled_classifications` (Bolt 5.6+).
+- `:gql_errors` — `true` on Bolt 5.7+ (GQL-compliant FAILURE: `neo4j_code`/`description` instead of `code`/`message`).
+- `:vectors` — `true` on Bolt 6.0+ (Vector PackStream struct, issue [#13](https://github.com/diffo-dev/bolty/issues/13)).
 
-Authoritative design (including calibration history and non-goals): [`.agent-notes/policy-design.md`](./.agent-notes/policy-design.md).
+**Server-capability** — derived from the HELLO `server` string, only meaningful in the post-HELLO policy (default `false` beforehand):
+
+- `:cypher_5` — server speaks `CYPHER 5` (Neo4j ≥ 5.0).
+- `:cypher_25` — server supports the `CYPHER 25` selector (Neo4j ≥ 2025.06).
+- `:dynamic_labels` — dynamic node labels/types (Neo4j ≥ 5.26); a strict superset of `:cypher_25`.
+
+To add a dimension: add the field to `Bolty.Policy`, extend `Bolty.Policy.Resolver` with a pure `put_*/3` clause, and dispatch the relevant codec/behaviour on it — do **not** bypass the boundary by reading a version number directly. Remember to update the docs too: the README "Negotiated capabilities" section and §11/§14 here.
 
 ## 15. Sharp edges / known quirks
 
@@ -325,24 +336,9 @@ the marker is preserved history.
 
 ## 17. Issues (GitHub)
 
-Snapshot from `.agent-notes/issues.json` — re-dump to refresh.
+Tracked live on GitHub — see [open issues](https://github.com/diffo-dev/bolty/issues) rather than a snapshot here (which only goes stale). No open issues at the time of writing.
 
-**Open**
-
-| # | Title | Label | Summary |
-| --- | --- | --- | --- |
-| [#12](https://github.com/diffo-dev/bolty/issues/12) | reuse compliance | enhancement | Make bolty (and its deps handling) REUSE-compliant. |
-| [#13](https://github.com/diffo-dev/bolty/issues/13) | vector | enhancement | Investigate Neo4j vector / vector-search support. DozerDB caps at Neo4j 5.26.3 so the useful envelope is bounded; may need negotiated Bolt-version behaviour. |
-| [#16](https://github.com/diffo-dev/bolty/issues/16) | boltx-era inheritance cleanup | maintenance | Drop `patch_bolt` dead wiring from `Bolty.Connection`, modernise `config/test.exs` and `.iex.exs` against the current `Bolty.Client.Config.new/1` option names, rewrite `Bolty.Response`'s Spanish docstring in English. Active on branch `16-boltx-related-maintenance`. |
-
-**Closed (for historical context)**
-
-| # | Title | Resolved in | Notes |
-| --- | --- | --- | --- |
-| [#5](https://github.com/diffo-dev/bolty/issues/5) | hex publish | 0.0.7 | Initial fork from `boltx` and Hex publication under the `bolty` name to avoid namespace collisions. |
-| [#6](https://github.com/diffo-dev/bolty/issues/6) | duration microseconds | 0.0.8 | Elixir `Duration` was being serialised to ISO8601 string rather than native Neo4j duration struct. |
-| [#8](https://github.com/diffo-dev/bolty/issues/8) | duration stored as string | 0.0.9 | Further fix — `Duration` outside of a map/struct wrapper was still being stored as a string. |
-| [#10](https://github.com/diffo-dev/bolty/issues/10) | dateTime param illegal | 0.0.10 | `%DateTime{}` was packed with the evolved 0x69 tag unconditionally and broke against Neo4j 5.x when `:versions` was constrained to Bolt 4.x. Fixed by policy-driven packstream: `%Bolty.Policy{datetime: :legacy \| :evolved}` resolved at HELLO, dispatched in the packer. See `.agent-notes/policy-design.md`. |
+Recent work shipped in **v0.2.0**: the `cypher_5`/`cypher_25`/`dynamic_labels` policy flags (#47–#49) and the type-hygiene / dialyzer + warnings-as-errors CI gate (#50). For closed history and rationale, browse the tracker or the [`CHANGELOG`](./CHANGELOG.md).
 
 ## 18. Licensing and REUSE
 


### PR DESCRIPTION
The v0.2.0 README omitted the cypher_5/cypher_25/dynamic_labels fields from the connection_info/1 example and the capability docs; add them (with a server- capability section, since they're server-version- not Bolt-version-derived). Refresh usage-rules §11/§14/§17 (vectors shipped; full policy dimension list; drop the dangling .agent-notes references and stale issues snapshot). Add an AGENTS.md with orientation and process notes for future maintainers/agents.