### PR TITLE
fix: recover connection after any FAILURE instead of leaving it FAILED (#54)

### DIFF
--- a/lib/bolty/client.ex
+++ b/lib/bolty/client.ex
@@ -514,13 +514,4 @@ defmodule Bolty.Client do
     sock_mod.close(sock)
     :ok
   end
-
-  def checkin(client) do
-    {sock_mod, sock} = client.sock
-
-    case sock_mod.setopts(sock, active: :once) do
-      :ok -> :ok
-      other -> other
-    end
-  end
 end

--- a/lib/bolty/connection.ex
+++ b/lib/bolty/connection.ex
@@ -53,6 +53,16 @@ defmodule Bolty.Connection do
   end
 
   @impl true
+  def handle_commit(_, %__MODULE__{in_transaction: false} = state) do
+    # A FAILURE earlier in this transaction already aborted it server-side and the
+    # connection was RESET back to a usable state (see execute/4). There is no
+    # server-side transaction left to commit, and sending COMMIT now would be
+    # rejected (Request.Invalid) and needlessly disconnect a healthy connection.
+    # Report the aborted-transaction status (:error) so the caller learns the
+    # commit did not happen, without tearing the connection down.
+    {:error, state}
+  end
+
   def handle_commit(_, %__MODULE__{client: client} = state) do
     case Client.send_commit(client) do
       {:ok, _} -> {:ok, :committed, %{state | in_transaction: false}}
@@ -61,6 +71,14 @@ defmodule Bolty.Connection do
   end
 
   @impl true
+  def handle_rollback(_, %__MODULE__{in_transaction: false} = state) do
+    # The transaction was already aborted by an earlier FAILURE and the connection
+    # RESET back to a usable state (see execute/4); there is nothing left to roll
+    # back. Sending ROLLBACK now would be rejected (Request.Invalid) and disconnect
+    # a healthy connection, so just report a successful rollback.
+    {:ok, :rolledback, state}
+  end
+
   def handle_rollback(_, %__MODULE__{client: client} = state) do
     case Client.send_rollback(client) do
       {:ok, _} -> {:ok, :rolledback, %{state | in_transaction: false}}
@@ -111,12 +129,6 @@ defmodule Bolty.Connection do
     end
   end
 
-  def checkin(state) do
-    case Client.disconnect(state.client) do
-      :ok -> {:ok, state}
-    end
-  end
-
   @impl true
   def handle_prepare(query, _opts, state), do: {:ok, query, state}
   @impl true
@@ -138,16 +150,33 @@ defmodule Bolty.Connection do
       {:ok, statement_result} ->
         {:ok, statement_result}
 
-      {:error, %Bolty.Error{code: error_code} = error} ->
-        if error_code in [:syntax_error, :semantic_error] and not state.in_transaction do
-          Client.send_reset(client)
-        end
-
-        {:error, error, state}
+      {:error, %Bolty.Error{} = error} ->
+        recover_from_failure(client, error, state)
     end
   rescue
     e ->
       {:error, e, state}
+  end
+
+  # A statement FAILURE leaves the Bolt connection in the protocol's FAILED state.
+  # Per the Bolt protocol the only way out is RESET — a ROLLBACK/COMMIT, or any
+  # further statement, is IGNORED. We therefore RESET after *any* FAILURE, for *any*
+  # error code, whether or not we are in a transaction. This recovers both:
+  #
+  #   * the in-transaction path — otherwise the trailing ROLLBACK is IGNORED and the
+  #     connection is force-disconnected (noisy `:ignored` error), and
+  #   * the bare-query path — otherwise the FAILED connection is returned to the pool
+  #     and poisons every later checkout with `:ignored` until it churns.
+  #
+  # After a successful RESET there is no server-side transaction left, so clear
+  # in_transaction; handle_rollback/handle_commit rely on that to avoid sending a
+  # ROLLBACK/COMMIT that the now-recovered connection would reject. If RESET itself
+  # fails the connection is genuinely unusable, so disconnect.
+  defp recover_from_failure(client, error, state) do
+    case Client.send_reset(client) do
+      {:ok, _} -> {:error, error, %{state | in_transaction: false}}
+      {:error, _reset_error} -> {:disconnect, error, state}
+    end
   end
 
   defp result(

--- a/lib/bolty/error.ex
+++ b/lib/bolty/error.ex
@@ -2,11 +2,25 @@
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.Error do
+  # Maps Neo4j status codes (https://neo4j.com/docs/status-codes/) to stable
+  # atoms. Anything not listed resolves to :unknown; the original Bolt status
+  # string is always preserved on `bolt.code`, so an unmapped code is never lost.
+  # Curated to the codes bolty callers actually branch on — notably
+  # ConstraintValidationFailed (identity uniqueness in ash_neo4j) and the
+  # retryable DeadlockDetected — verified against Neo4j 5.26.x and 2026.x.
   @error_map %{
+    # Security / request
     "Neo.ClientError.Security.Unauthorized" => :unauthorized,
     "Neo.ClientError.Request.Invalid" => :request_invalid,
+    # Statement
+    "Neo.ClientError.Statement.SyntaxError" => :syntax_error,
     "Neo.ClientError.Statement.SemanticError" => :semantic_error,
-    "Neo.ClientError.Statement.SyntaxError" => :syntax_error
+    "Neo.ClientError.Statement.ArithmeticError" => :arithmetic_error,
+    "Neo.ClientError.Statement.ParameterMissing" => :parameter_missing,
+    # Schema — the production-common constraint violation
+    "Neo.ClientError.Schema.ConstraintValidationFailed" => :constraint_validation_failed,
+    # Transient — safe to retry
+    "Neo.TransientError.Transaction.DeadlockDetected" => :deadlock_detected
   }
 
   @type t() :: %__MODULE__{

--- a/test/bolty/connection_recovery_test.exs
+++ b/test/bolty/connection_recovery_test.exs
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Bolty.ConnectionRecoveryTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  # Regression coverage for #54: a statement FAILURE must leave the pooled
+  # connection usable (RESET back to READY) rather than stuck in the Bolt FAILED
+  # state. Before the fix this produced an IGNORED rollback + a noisy `:ignored`
+  # disconnect inside a transaction, and silently poisoned the pooled connection
+  # for bare queries (every later checkout returned `:ignored` until it churned).
+  #
+  # Each test drives its own `pool_size: 1` pool so the same connection is reused
+  # across checkouts — that is what makes a poisoned connection observable.
+
+  @opts Bolty.TestHelper.opts()
+
+  defp pool do
+    {:ok, pool} = Bolty.start_link([pool_size: 1] ++ @opts)
+    pool
+  end
+
+  describe "recovery after an in-transaction FAILURE (#54)" do
+    @tag :core
+    test "rolling back after a failed query neither disconnects nor leaves :ignored noise" do
+      pool = pool()
+
+      log =
+        capture_log(fn ->
+          result =
+            Bolty.transaction(pool, fn conn ->
+              assert {:error, %Bolty.Error{}} = Bolty.query(conn, "RETURN 1 / 0")
+              Bolty.rollback(conn, :done)
+            end)
+
+          assert {:error, :done} = result
+        end)
+
+      refute log =~ ":ignored", "rollback over a FAILED connection must not surface :ignored"
+      refute log =~ "disconnected", "an in-transaction failure must not force-disconnect"
+    end
+
+    @tag :core
+    test "the connection is reusable after an in-transaction failure" do
+      pool = pool()
+
+      Bolty.transaction(pool, fn conn ->
+        assert {:error, %Bolty.Error{}} = Bolty.query(conn, "RETURN 1 / 0")
+        Bolty.rollback(conn, :done)
+      end)
+
+      assert {:ok, response} = Bolty.query(pool, "RETURN 7 AS n")
+      assert [%{"n" => 7}] = response.results
+    end
+
+    @tag :core
+    test "a constraint violation is classified and recovers cleanly (the ash_neo4j case)" do
+      pool = pool()
+      label = "RecoveryUniq#{System.unique_integer([:positive])}"
+
+      # Uniquely-named constraint is the only shared state; both conflicting creates
+      # live inside the transaction (and are rolled back), so a concurrent global
+      # node-wipe in another async test cannot interfere with this test.
+      Bolty.query!(pool, "CREATE CONSTRAINT FOR (n:#{label}) REQUIRE n.k IS UNIQUE")
+
+      log =
+        capture_log(fn ->
+          Bolty.transaction(pool, fn conn ->
+            assert {:ok, _} = Bolty.query(conn, "CREATE (:#{label} {k: 'x'})")
+
+            assert {:error, %Bolty.Error{code: :constraint_validation_failed} = error} =
+                     Bolty.query(conn, "CREATE (:#{label} {k: 'x'})")
+
+            assert error.bolt.code == "Neo.ClientError.Schema.ConstraintValidationFailed"
+            Bolty.rollback(conn, :done)
+          end)
+        end)
+
+      refute log =~ ":ignored"
+      refute log =~ "disconnected"
+
+      # connection still usable
+      assert {:ok, _} = Bolty.query(pool, "RETURN 1 AS n")
+
+      Bolty.query(pool, "DROP CONSTRAINT FOR (n:#{label}) REQUIRE n.k IS UNIQUE")
+    end
+  end
+
+  describe "recovery after a bare-query FAILURE outside a transaction (#54)" do
+    @tag :core
+    test "a failed query does not poison later checkouts of the pooled connection" do
+      pool = pool()
+
+      assert {:error, %Bolty.Error{}} = Bolty.query(pool, "RETURN 1 / 0")
+
+      for i <- 1..5 do
+        assert {:ok, response} = Bolty.query(pool, "RETURN #{i} AS n"),
+               "query #{i} after a failure should succeed, not hit a poisoned (:ignored) connection"
+
+        assert [%{"n" => ^i}] = response.results
+      end
+    end
+  end
+
+  describe "the happy path is unaffected (#54)" do
+    @tag :core
+    test "a transaction with no failure still commits" do
+      pool = pool()
+      label = "Recovery#{System.unique_integer([:positive])}"
+
+      assert {:ok, :ok} =
+               Bolty.transaction(pool, fn conn ->
+                 assert {:ok, _} = Bolty.query(conn, "CREATE (:#{label} {k: 1})")
+                 :ok
+               end)
+
+      assert {:ok, response} = Bolty.query(pool, "MATCH (n:#{label}) RETURN count(n) AS c")
+      assert [%{"c" => 1}] = response.results
+
+      Bolty.query(pool, "MATCH (n:#{label}) DETACH DELETE n")
+    end
+  end
+end

--- a/test/bolty/connection_test.exs
+++ b/test/bolty/connection_test.exs
@@ -51,23 +51,6 @@ defmodule Bolty.ConnectionTest do
     :ok = Connection.disconnect(:stop, conn_data)
   end
 
-  @tag core: true
-  test "checkin/1 successful" do
-    {:ok,
-     %Connection{client: client, server_version: server_version, connection_id: connection_id} =
-       conn_data} =
-      Connection.connect(@opts)
-
-    assert is_bitstring(server_version)
-    assert is_bitstring(connection_id)
-    assert is_float(client.bolt_version)
-
-    assert {:ok, %Connection{client: _} = conn_data} =
-             Connection.checkin(conn_data)
-
-    :ok = Connection.disconnect(:stop, conn_data)
-  end
-
   @tag :core
   test "connect/1 fails when connection is not available" do
     opts = [
@@ -91,9 +74,6 @@ defmodule Bolty.ConnectionTest do
     assert is_bitstring(connection_id)
     assert String.contains?(connection_id, "bolt-")
 
-    assert {:ok, %Connection{client: _} = conn_data} =
-             Connection.checkin(conn_data)
-
     :ok = Connection.disconnect(:stop, conn_data)
   end
 
@@ -108,9 +88,6 @@ defmodule Bolty.ConnectionTest do
     assert client.bolt_version == 5.1
     assert is_bitstring(connection_id)
     assert String.contains?(connection_id, "bolt-")
-
-    assert {:ok, %Connection{client: _} = conn_data} =
-             Connection.checkin(conn_data)
 
     :ok = Connection.disconnect(:stop, conn_data)
   end
@@ -127,9 +104,6 @@ defmodule Bolty.ConnectionTest do
     assert is_bitstring(connection_id)
     assert String.contains?(connection_id, "bolt-")
 
-    assert {:ok, %Connection{client: _} = conn_data} =
-             Connection.checkin(conn_data)
-
     :ok = Connection.disconnect(:stop, conn_data)
   end
 
@@ -144,9 +118,6 @@ defmodule Bolty.ConnectionTest do
     assert client.bolt_version == 5.3
     assert is_bitstring(connection_id)
     assert String.contains?(connection_id, "bolt-")
-
-    assert {:ok, %Connection{client: _} = conn_data} =
-             Connection.checkin(conn_data)
 
     :ok = Connection.disconnect(:stop, conn_data)
   end
@@ -163,9 +134,6 @@ defmodule Bolty.ConnectionTest do
     assert is_bitstring(connection_id)
     assert String.contains?(connection_id, "bolt-")
 
-    assert {:ok, %Connection{client: _} = conn_data} =
-             Connection.checkin(conn_data)
-
     :ok = Connection.disconnect(:stop, conn_data)
   end
 
@@ -180,9 +148,6 @@ defmodule Bolty.ConnectionTest do
     assert client.bolt_version == 5.6
     assert is_bitstring(connection_id)
     assert String.contains?(connection_id, "bolt-")
-
-    assert {:ok, %Connection{client: _} = conn_data} =
-             Connection.checkin(conn_data)
 
     :ok = Connection.disconnect(:stop, conn_data)
   end
@@ -199,9 +164,6 @@ defmodule Bolty.ConnectionTest do
     assert is_bitstring(connection_id)
     assert String.contains?(connection_id, "bolt-")
 
-    assert {:ok, %Connection{client: _} = conn_data} =
-             Connection.checkin(conn_data)
-
     :ok = Connection.disconnect(:stop, conn_data)
   end
 
@@ -216,9 +178,6 @@ defmodule Bolty.ConnectionTest do
     assert client.bolt_version == 5.8
     assert is_bitstring(connection_id)
     assert String.contains?(connection_id, "bolt-")
-
-    assert {:ok, %Connection{client: _} = conn_data} =
-             Connection.checkin(conn_data)
 
     :ok = Connection.disconnect(:stop, conn_data)
   end
@@ -237,9 +196,6 @@ defmodule Bolty.ConnectionTest do
     assert client.bolt_version == last_version
     assert is_bitstring(connection_id)
     assert String.contains?(connection_id, "bolt-")
-
-    assert {:ok, %Connection{client: _} = conn_data} =
-             Connection.checkin(conn_data)
 
     :ok = Connection.disconnect(:stop, conn_data)
   end

--- a/test/bolty/error_test.exs
+++ b/test/bolty/error_test.exs
@@ -37,6 +37,44 @@ defmodule Bolty.ErrorTest do
     end
   end
 
+  describe "Error.to_atom/1 status-code mapping (#54)" do
+    @tag :core
+    test "maps the curated Neo4j status codes to stable atoms" do
+      assert Error.to_atom("Neo.ClientError.Security.Unauthorized") == :unauthorized
+      assert Error.to_atom("Neo.ClientError.Request.Invalid") == :request_invalid
+      assert Error.to_atom("Neo.ClientError.Statement.SyntaxError") == :syntax_error
+      assert Error.to_atom("Neo.ClientError.Statement.SemanticError") == :semantic_error
+      assert Error.to_atom("Neo.ClientError.Statement.ArithmeticError") == :arithmetic_error
+      assert Error.to_atom("Neo.ClientError.Statement.ParameterMissing") == :parameter_missing
+
+      assert Error.to_atom("Neo.ClientError.Schema.ConstraintValidationFailed") ==
+               :constraint_validation_failed
+
+      assert Error.to_atom("Neo.TransientError.Transaction.DeadlockDetected") ==
+               :deadlock_detected
+    end
+
+    @tag :core
+    test "unmapped codes resolve to :unknown but keep the raw status on bolt.code" do
+      assert Error.to_atom("Neo.ClientError.Statement.NotInMap") == :unknown
+
+      error =
+        Error.wrap(Bolty.Client, %{
+          code: "Neo.ClientError.Statement.NotInMap",
+          message: "boom"
+        })
+
+      assert error.code == :unknown
+      assert error.bolt.code == "Neo.ClientError.Statement.NotInMap"
+    end
+
+    @tag :core
+    test "an already-resolved atom passes through unchanged" do
+      assert Error.to_atom(:constraint_validation_failed) == :constraint_validation_failed
+      assert Error.to_atom(:unknown) == :unknown
+    end
+  end
+
   describe "PullMessage.format_error/1" do
     @tag :core
     test "formats :unsupported_message_version" do


### PR DESCRIPTION
Fixes #54.

## Problem

A statement FAILURE leaves the Bolt connection in the protocol's FAILED state, from which only `RESET` recovers — a `ROLLBACK`/`COMMIT` (or any further statement) is `IGNORED`. Recovery previously fired only for `:syntax_error`/`:semantic_error` **and** only outside a transaction, so any other failure left the connection FAILED:

- **In a transaction:** the trailing `ROLLBACK` is `IGNORED`, `handle_rollback` returns `{:disconnect, …}`, and the connection is force-disconnected with a noisy `[error] … :ignored`.
- **On a bare query:** the FAILED connection returns to the pool and poisons every later checkout with `:ignored` until it churns (the more dangerous, silent case).

This hit every non-syntax failure, notably `ConstraintValidationFailed` (ash_neo4j identity uniqueness, diffo-dev/ash_neo4j#20).

## Fix

- **`execute/4` RESETs after *any* FAILURE** — any error code, in or out of a transaction — and clears `in_transaction`. If `RESET` itself fails the connection is genuinely dead → `:disconnect`.
- **`handle_rollback`/`handle_commit` cooperate.** Probing the protocol showed a bare RESET is *insufficient*: after RESET the connection is READY with no active tx, so the ROLLBACK/COMMIT DBConnection still issues returns `Request.Invalid` and kills the connection. When the tx was already reset (`in_transaction: false`) rollback now reports success and commit reports the aborted status — neither disconnects.
- **`@error_map` curated expansion** so `ConstraintValidationFailed`, `ArithmeticError`, `ParameterMissing` and the retryable `DeadlockDetected` classify to stable atoms instead of `:unknown` (raw status still preserved on `bolt.code`).
- **Removed dead `checkin/1`** from `Connection` and `Client` — never wired (DBConnection has no `checkin` callback) and uncallable by consumers.

## Tests

- New `test/bolty/connection_recovery_test.exs` — locks both recovery paths (in-tx rollback → no `:ignored`/disconnect + reusable connection; bare-query → no pool poisoning), the constraint-violation case, and the happy path.
- New `Bolty.Error` mapping tests (each curated code + `:unknown` fallback).
- Full matrix green: **Bolt 5.0–5.8, 6.0, and both-range negotiation** against Neo4j 5.26.27 and 2026.05.

Detailed reproduction and design notes are journaled on #54.