### PR TITLE
fix: reassemble multi-chunk Bolt messages on the receive path (#57)

### DIFF
--- a/lib/bolty/client.ex
+++ b/lib/bolty/client.ex
@@ -5,7 +5,6 @@ defmodule Bolty.Client do
   @moduledoc false
 
   @handshake_bytes_identifier <<0x60, 0x60, 0xB0, 0x17>>
-  @noop_chunk <<0x00, 0x00>>
   @summary ~w(success ignored failure)a
 
   import Bolty.BoltProtocol.ServerResponse
@@ -449,22 +448,39 @@ defmodule Bolty.Client do
       {:ok, message_record} ->
         recv_packets(client, prepare_messages, timeout, [message_record | messages])
 
-      :remaining_chunks ->
-        recv_packets(client, prepare_messages, timeout, messages)
-
       {:error, _} = error ->
         error
     end
   end
 
   defp get_next_message(client, timeout) do
-    with {:ok, chunk_size} <- get_chunk_size(client, timeout),
-         {:ok, <<message_binary::binary>>} <- get_chunk(client, timeout, chunk_size),
+    with {:ok, message_binary} <- read_chunks(client, timeout, <<>>),
          {:ok, message} <- decode_message(message_binary) do
       {:ok, message}
-    else
-      :remaining_chunks ->
-        :remaining_chunks
+    end
+  end
+
+  # A Bolt message is transmitted as one or more chunks, each prefixed with a
+  # uint16 length, and terminated by a zero-length (0x0000) chunk. Accumulate the
+  # chunk payloads until that end-marker, then return the concatenated message
+  # body. This correctly reassembles a message the server splits across several
+  # chunks — which the protocol permits for any message, not only those larger
+  # than 65_535 bytes — rather than assuming one chunk per message.
+  #
+  # A 0x0000 read with nothing accumulated is a standalone NOOP / keep-alive
+  # boundary, so it is skipped rather than decoded as an empty message.
+  defp read_chunks(client, timeout, acc) do
+    case get_chunk_size(client, timeout) do
+      {:ok, 0} when acc == <<>> ->
+        read_chunks(client, timeout, acc)
+
+      {:ok, 0} ->
+        {:ok, acc}
+
+      {:ok, chunk_size} ->
+        with {:ok, chunk} <- get_chunk(client, timeout, chunk_size) do
+          read_chunks(client, timeout, <<acc::binary, chunk::binary>>)
+        end
 
       {:error, _} = error ->
         error
@@ -473,17 +489,11 @@ defmodule Bolty.Client do
 
   defp get_chunk_size(client, timeout) do
     case recv_data(client, timeout, 2) do
-      {:ok, @noop_chunk} ->
-        :remaining_chunks
-
       {:ok, <<chunk_size::16>>} ->
-        {:ok, chunk_size + byte_size(@noop_chunk)}
+        {:ok, chunk_size}
 
-      {:error, :timeout} ->
-        {:error, Bolty.Error.wrap(__MODULE__, :timeout)}
-
-      {:error, _} = error ->
-        error
+      {:error, reason} ->
+        {:error, Bolty.Error.wrap(__MODULE__, reason)}
     end
   end
 
@@ -492,11 +502,8 @@ defmodule Bolty.Client do
       {:ok, <<chunk::binary>>} ->
         {:ok, chunk}
 
-      {:error, :timeout} ->
-        {:error, Bolty.Error.wrap(__MODULE__, :timeout)}
-
-      {:error, _} = error ->
-        error
+      {:error, reason} ->
+        {:error, Bolty.Error.wrap(__MODULE__, reason)}
     end
   end
 

--- a/test/bolty/client_test.exs
+++ b/test/bolty/client_test.exs
@@ -11,6 +11,13 @@ defmodule Bolty.ClientTest do
   @opts Bolty.TestHelper.opts()
   @noop_chunk <<0x00, 0x00>>
 
+  # Frame a message body the way Bolt does on the wire: one or more
+  # [uint16 length][payload] chunks terminated by a zero-length (0x0000) chunk.
+  # `framed/1` emits a single-chunk message; `body/1` strips the trailing 0x0000
+  # the older fixtures baked into their payloads, leaving the true message body.
+  defp framed(payload), do: [<<byte_size(payload)::16>>, payload, @noop_chunk]
+  defp body(full), do: binary_part(full, 0, byte_size(full) - 2)
+
   defp handle_handshake(client, opts) do
     case client.bolt_version do
       version when version >= 5.1 ->
@@ -174,7 +181,7 @@ defmodule Bolty.ClientTest do
           101, 111, 117, 116, 95, 115, 101, 99, 111, 110, 100, 115, 120, 208, 17, 116, 101, 108,
           101, 109, 101, 116, 114, 121, 46, 101, 110, 97, 98, 108, 101, 100, 194, 0, 0>>
 
-      pid = Bolty.Mocks.SockMock.start_link([<<0, byte_size(chunk)>>, chunk])
+      pid = Bolty.Mocks.SockMock.start_link(framed(body(chunk)))
       client = %{sock: {Bolty.Mocks.SockMock, pid}, bolt_version: 1.0}
       {:ok, message} = Client.recv_packets(client, fn _bolt_version, data -> {:ok, data} end, 0)
 
@@ -203,14 +210,7 @@ defmodule Bolty.ClientTest do
           101, 111, 117, 116, 95, 115, 101, 99, 111, 110, 100, 115, 120, 208, 17, 116, 101, 108,
           101, 109, 101, 116, 114, 121, 46, 101, 110, 97, 98, 108, 101, 100, 194, 0, 0>>
 
-      pid =
-        Bolty.Mocks.SockMock.start_link([
-          <<0, byte_size(chunk1)>>,
-          chunk1,
-          @noop_chunk,
-          <<0, byte_size(chunk2)>>,
-          chunk2
-        ])
+      pid = Bolty.Mocks.SockMock.start_link(framed(body(chunk1)) ++ framed(body(chunk2)))
 
       client = %{sock: {Bolty.Mocks.SockMock, pid}, bolt_version: 3.0}
       {:ok, message} = Client.recv_packets(client, fn _bolt_version, data -> {:ok, data} end, 0)
@@ -242,14 +242,9 @@ defmodule Bolty.ClientTest do
           101, 109, 101, 116, 114, 121, 46, 101, 110, 97, 98, 108, 101, 100, 194, 0, 0>>
 
       pid =
-        Bolty.Mocks.SockMock.start_link([
-          @noop_chunk,
-          <<0, byte_size(chunk1)>>,
-          chunk1,
-          @noop_chunk,
-          <<0, byte_size(chunk2)>>,
-          chunk2
-        ])
+        Bolty.Mocks.SockMock.start_link(
+          [@noop_chunk] ++ framed(body(chunk1)) ++ [@noop_chunk] ++ framed(body(chunk2))
+        )
 
       client = %{sock: {Bolty.Mocks.SockMock, pid}, bolt_version: 5.0}
       {:ok, message} = Client.recv_packets(client, fn _bolt_version, data -> {:ok, data} end, 0)
@@ -266,6 +261,27 @@ defmodule Bolty.ClientTest do
                 }},
                {:record, [1024, 2048]}
              ]
+    end
+
+    @tag :core
+    test "reassembles a single message split across multiple chunks (#57)" do
+      # One RECORD body split across two data chunks with no terminator between
+      # them, followed by an empty SUCCESS summary. The old reader assumed one
+      # chunk per message and desynced on the second chunk's size header.
+      record = <<177, 113, 146, 201, 4, 0, 201, 8, 0>>
+      head = binary_part(record, 0, 5)
+      tail = binary_part(record, 5, byte_size(record) - 5)
+      success = <<177, 112, 160>>
+
+      frames =
+        [<<byte_size(head)::16>>, head, <<byte_size(tail)::16>>, tail, @noop_chunk] ++
+          framed(success)
+
+      pid = Bolty.Mocks.SockMock.start_link(frames)
+      client = %{sock: {Bolty.Mocks.SockMock, pid}, bolt_version: 5.0}
+      {:ok, message} = Client.recv_packets(client, fn _bolt_version, data -> {:ok, data} end, 0)
+
+      assert message == [{:success, %{}}, {:record, [1024, 2048]}]
     end
   end
 

--- a/test/large_result_set_test.exs
+++ b/test/large_result_set_test.exs
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Large.Result.Set.Test do
+  use ExUnit.Case, async: true
+
+  # Regression for #57: a result message larger than a single Bolt chunk
+  # (> 65_535 bytes) is split by the server across multiple chunks. The reader
+  # must reassemble the chunk payloads before decoding; previously it assumed
+  # one chunk per message, desynced the stream, and raised in the decoder.
+
+  @opts Bolty.TestHelper.opts()
+
+  setup do
+    {:ok, conn} = Bolty.start_link([pool_size: 1] ++ @opts)
+    {:ok, conn: conn}
+  end
+
+  @tag :core
+  test "reassembles a single record far larger than one chunk", %{conn: conn} do
+    # A 100_000-element integer list encodes to several hundred KB in one RECORD,
+    # forcing the server to split that message across multiple chunks.
+    assert {:ok, response} = Bolty.query(conn, "RETURN range(1, 100000) AS nums")
+    nums = List.first(response.results)["nums"]
+
+    assert length(nums) == 100_000
+    assert List.first(nums) == 1
+    assert List.last(nums) == 100_000
+  end
+
+  @tag :core
+  test "the connection stays usable after a large result", %{conn: conn} do
+    assert {:ok, _} = Bolty.query(conn, "RETURN range(1, 100000) AS nums")
+
+    assert {:ok, response} = Bolty.query(conn, "RETURN 7 AS n")
+    assert [%{"n" => 7}] = response.results
+  end
+end


### PR DESCRIPTION
Fixes #57.

## Problem

The message reader assumed **one chunk per message**. `get_chunk_size` read a uint16 length and then read `length + 2` bytes, baking in the assumption that a single chunk plus the `0x0000` end-marker formed the whole message. When the server split a message across **two or more chunks** — which the Bolt chunking protocol permits for *any* message, not only those over 65 535 bytes — the reader consumed the next chunk's size header as part of the body, desynced the stream, and raised in the decoder.

Reproduced on both 5.26.27 and 2026.05: `RETURN range(1, 100000) AS nums` (a single record far larger than one chunk) raised a `FunctionClauseError` from `MessageDecoder.decode/1` and left the connection unusable. Under CI timing this also surfaced even for sub-64 KB messages (server/TLS/TCP segmentation), as the `{:error, :closed}` / `CaseClauseError` cascade in the issue.

## Fix

- **Reassemble per the protocol** — accumulate chunk payloads until the zero-length (`0x0000`) terminator, then decode the concatenation (`read_chunks/3`). A standalone `0x0000` with nothing accumulated is a NOOP / keep-alive and is skipped.
- **Graceful transport errors** — wrap raw socket errors (e.g. `:closed`) from the recv path in a `%Bolty.Error{}`, so a mid-message drop surfaces cleanly instead of as a `CaseClauseError` downstream.

## Tests

- **Unit:** a new `recv_packets` test reassembling a single message split across two chunks; the existing `recv_packets` fixtures reframed to correct Bolt framing (the old fixtures baked the terminator into the payload to satisfy the buggy reader).
- **Integration:** new `test/large_result_set_test.exs` pulling a 100 000-element record (several hundred KB, multi-chunk) and asserting correct reassembly + a usable connection afterward.
- Full matrix green: **5.0–5.8, 6.0, both-range negotiation** on Neo4j 5.26.27 and 2026.05; dialyzer 0 errors; format clean.

This is the change that unblocks diffo_example CI (#57). Distinct from #54/#56 (FAILED-state RESET) and #58 (rescue hardening).