### PR TITLE
fix: disconnect with the original error if a recovery RESET raises (#58)

### DIFF
--- a/lib/bolty/connection.ex
+++ b/lib/bolty/connection.ex
@@ -171,12 +171,16 @@ defmodule Bolty.Connection do
   # After a successful RESET there is no server-side transaction left, so clear
   # in_transaction; handle_rollback/handle_commit rely on that to avoid sending a
   # ROLLBACK/COMMIT that the now-recovered connection would reject. If RESET itself
-  # fails the connection is genuinely unusable, so disconnect.
+  # fails — returning an error or raising — the connection is genuinely unusable,
+  # so disconnect. Crucially we disconnect with the *original* query `error`: a
+  # failed RESET must never mask what the caller was actually told went wrong.
   defp recover_from_failure(client, error, state) do
     case Client.send_reset(client) do
       {:ok, _} -> {:error, error, %{state | in_transaction: false}}
       {:error, _reset_error} -> {:disconnect, error, state}
     end
+  rescue
+    _ -> {:disconnect, error, state}
   end
 
   defp result(

--- a/test/bolty/connection_recovery_test.exs
+++ b/test/bolty/connection_recovery_test.exs
@@ -110,16 +110,22 @@ defmodule Bolty.ConnectionRecoveryTest do
       pool = pool()
       label = "Recovery#{System.unique_integer([:positive])}"
 
+      # {:ok, :ok} is the regression guard: a clean transaction must run the commit
+      # path (handle_commit -> :committed) and not the aborted-status guard added in
+      # #54 — DBConnection turns that guard into {:error, :rollback}, not {:ok, :ok}.
+      # Visibility is asserted *inside* the transaction; a follow-up read on a later
+      # query can race the suite's async global truncate (MATCH (n) DETACH DELETE n
+      # in bolty_test) deleting the committed node, which flakes (observed on CI).
       assert {:ok, :ok} =
                Bolty.transaction(pool, fn conn ->
                  assert {:ok, _} = Bolty.query(conn, "CREATE (:#{label} {k: 1})")
+
+                 assert {:ok, response} =
+                          Bolty.query(conn, "MATCH (n:#{label}) RETURN count(n) AS c")
+
+                 assert [%{"c" => 1}] = response.results
                  :ok
                end)
-
-      assert {:ok, response} = Bolty.query(pool, "MATCH (n:#{label}) RETURN count(n) AS c")
-      assert [%{"c" => 1}] = response.results
-
-      Bolty.query(pool, "MATCH (n:#{label}) DETACH DELETE n")
     end
   end
 end

--- a/test/bolty/connection_reset_rescue_test.exs
+++ b/test/bolty/connection_reset_rescue_test.exs
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Bolty.ConnectionResetRescueTest do
+  use ExUnit.Case, async: true
+
+  # Regression for #58: a statement FAILURE triggers a recovery RESET. If that
+  # RESET *raises* (rather than returning {:error, …}) the connection is unusable,
+  # but the caller must still be disconnected with the ORIGINAL query error — a
+  # failed RESET must never mask what actually went wrong.
+
+  # A socket double: `recv/3` replays a scripted list of binaries (one per call),
+  # `send/2` is a no-op. Lets us drive the client through an exact server-response
+  # sequence without a real connection.
+  defmodule ScriptedSock do
+    @moduledoc false
+    def start(frames), do: Agent.start_link(fn -> frames end)
+    def send(_sock, _data), do: :ok
+
+    def recv(agent, _length, _timeout) do
+      {:ok, Agent.get_and_update(agent, fn [frame | rest] -> {frame, rest} end)}
+    end
+  end
+
+  @tag :core
+  test "a RESET that raises disconnects with the original error, not the reset failure" do
+    # Wire framing is [uint16 len][payload] chunks terminated by 0x0000.
+    frames = [
+      # RUN response: FAILURE carrying %{"code" => "X"} (the original error).
+      <<0, 10>>,
+      <<177, 127, 161, 132, 99, 111, 100, 101, 129, 88>>,
+      <<0, 0>>,
+      # RESET response: an undecodable body, so MessageDecoder.decode/1 raises
+      # mid-recovery — exercising the rescue added for #58.
+      <<0, 1>>,
+      <<0>>,
+      <<0, 0>>
+    ]
+
+    {:ok, agent} = ScriptedSock.start(frames)
+
+    client = %Bolty.Client{
+      sock: {ScriptedSock, agent},
+      bolt_version: 5.0,
+      policy: Bolty.Policy.Resolver.resolve(5.0, %{})
+    }
+
+    state = %Bolty.Connection{client: client, in_transaction: false}
+    query = %Bolty.Query{statement: "RETURN 1", extra: %{}}
+
+    result = Bolty.Connection.handle_execute(query, %{}, [], state)
+
+    # Disconnect (the connection is unusable), and the surfaced error is the
+    # original RUN failure (bolt.code "X") — not the RESET's raised exception.
+    assert {:disconnect, %Bolty.Error{bolt: %{code: "X"}}, _state} = result
+  end
+end


### PR DESCRIPTION
Fixes #58. Follow-up hardening to #56, surfaced while comparing against boltx #145.

## Problem

After a statement FAILURE, `execute/4` sends `RESET` to recover the FAILED connection (#54/#56). `recover_from_failure/3` ran inside `execute/4`'s `rescue`, so the common reset-failure mode — `Client.send_reset/1` returning `{:error, …}` — was handled by disconnecting with the original error. But if `send_reset/1` *raised* instead (e.g. an undecodable RESET response), the outer rescue caught it and returned `{:error, <reset exception>, state}`, **masking the caller's original query error**.

Low likelihood (sockets normally return `{:error, …}` tuples rather than raising), but a real correctness gap.

## Fix

`rescue` inside `recover_from_failure/3`: a RESET that raises means the connection is unusable, so disconnect — but with the **original** `%Bolty.Error{}`, never the reset failure. The `{:ok, …}` and `{:error, …}` reset paths are unchanged.

```elixir
defp recover_from_failure(client, error, state) do
  case Client.send_reset(client) do
    {:ok, _} -> {:error, error, %{state | in_transaction: false}}
    {:error, _reset_error} -> {:disconnect, error, state}
  end
rescue
  _ -> {:disconnect, error, state}
end
```

## Tests

New `connection_reset_rescue_test.exs` drives the real `execute -> recover_from_failure` path via a scripted socket double that returns a FAILURE for the RUN then makes the RESET raise (undecodable response), asserting the disconnect carries the **original** error (`bolt.code "X"`), not the reset's exception. Verified it **fails without the fix** (returns `{:error, %FunctionClauseError{}}`).

Full matrix green (5.0–5.8, 6.0, negotiation) on Neo4j 5.26.27 and 2026.05; dialyzer 0 errors; format clean.