### PR TITLE
fix: return bound Relationship structs from Path.graph/1 (#55)

### DIFF
--- a/lib/bolty/types.ex
+++ b/lib/bolty/types.ex
@@ -164,32 +164,38 @@ defmodule Bolty.Types do
     defp draw_path(n, r, s, i, [h | t] = _rel_index, acc, ln, _nn) do
       next_node = Enum.at(n, Enum.at(s, 2 * i + 1))
 
-      urel =
+      # graph/1 binds each relationship to its endpoints in the walk, so the result
+      # is a %Relationship{} (which carries :start/:end) rather than the endpoint-less
+      # wire %UnboundRelationship{}. struct/2 silently drops unknown keys, so building
+      # an UnboundRelationship here would lose the computed :start/:end (issue #55).
+      relationship =
         if h > 0 && h < 255 do
-          # rel: rels[rel_index - 1], start/end: (ln.id, next_node.id)
+          # forward traversal: start = last node, end = next node
           rel = Enum.at(r, h - 1)
 
-          unbound_relationship =
-            [:id, :type, :properties, :start, :end]
-            |> Enum.zip([rel.id, rel.type, rel.properties, ln.id, next_node.id])
+          fields =
+            Enum.zip(
+              [:id, :type, :properties, :start, :end],
+              [rel.id, rel.type, rel.properties, ln.id, next_node.id]
+            )
 
-          struct(UnboundRelationship, unbound_relationship)
+          struct(Relationship, fields)
         else
-          # rel: rels[-rel_index - 1], start/end: (next_node.id, ln.id)
-          # Neo4j sends: -1, and Bolty.Internals. returns 255 instead? Investigating,
-          # meanwhile ugly path:
-          # oh dear ...
-          haha = if h == 255, do: -1, else: h
-          rel = Enum.at(r, -haha - 1)
+          # reverse traversal: start = next node, end = last node. Neo4j encodes the
+          # reverse index as a negative; the unpacker surfaces -1 as 255, so map it back.
+          rel_index = if h == 255, do: -1, else: h
+          rel = Enum.at(r, -rel_index - 1)
 
-          unbound_relationship =
-            [:id, :type, :properties, :start, :end]
-            |> Enum.zip([rel.id, rel.type, rel.properties, next_node.id, ln.id])
+          fields =
+            Enum.zip(
+              [:id, :type, :properties, :start, :end],
+              [rel.id, rel.type, rel.properties, next_node.id, ln.id]
+            )
 
-          struct(UnboundRelationship, unbound_relationship)
+          struct(Relationship, fields)
         end
 
-      draw_path(n, r, s, i + 1, t, (acc ++ [urel]) ++ [next_node], next_node, ln)
+      draw_path(n, r, s, i + 1, t, (acc ++ [relationship]) ++ [next_node], next_node, ln)
     end
   end
 

--- a/test/bolty/connection_recovery_test.exs
+++ b/test/bolty/connection_recovery_test.exs
@@ -60,31 +60,40 @@ defmodule Bolty.ConnectionRecoveryTest do
       pool = pool()
       label = "RecoveryUniq#{System.unique_integer([:positive])}"
 
-      # Uniquely-named constraint is the only shared state; both conflicting creates
-      # live inside the transaction (and are rolled back), so a concurrent global
-      # node-wipe in another async test cannot interfere with this test.
-      Bolty.query!(pool, "CREATE CONSTRAINT FOR (n:#{label}) REQUIRE n.k IS UNIQUE")
+      # The named constraint is the only cross-test shared state; both conflicting
+      # creates live inside the (rolled-back) transaction, so a concurrent global
+      # node-wipe can't interfere. CREATE ... IF NOT EXISTS plus a DROP-by-name in an
+      # `after` (runs even on failure; the pool is still alive, unlike on_exit) keep
+      # it idempotent: System.unique_integer resets per VM, and the old schema-style
+      # DROP errored on 5.x (silently, via non-bang query), so on a shared/persistent
+      # DB constraints leaked and collided across runs (EquivalentSchemaRuleAlreadyExists).
+      Bolty.query!(
+        pool,
+        "CREATE CONSTRAINT #{label} IF NOT EXISTS FOR (n:#{label}) REQUIRE n.k IS UNIQUE"
+      )
 
-      log =
-        capture_log(fn ->
-          Bolty.transaction(pool, fn conn ->
-            assert {:ok, _} = Bolty.query(conn, "CREATE (:#{label} {k: 'x'})")
+      try do
+        log =
+          capture_log(fn ->
+            Bolty.transaction(pool, fn conn ->
+              assert {:ok, _} = Bolty.query(conn, "CREATE (:#{label} {k: 'x'})")
 
-            assert {:error, %Bolty.Error{code: :constraint_validation_failed} = error} =
-                     Bolty.query(conn, "CREATE (:#{label} {k: 'x'})")
+              assert {:error, %Bolty.Error{code: :constraint_validation_failed} = error} =
+                       Bolty.query(conn, "CREATE (:#{label} {k: 'x'})")
 
-            assert error.bolt.code == "Neo.ClientError.Schema.ConstraintValidationFailed"
-            Bolty.rollback(conn, :done)
+              assert error.bolt.code == "Neo.ClientError.Schema.ConstraintValidationFailed"
+              Bolty.rollback(conn, :done)
+            end)
           end)
-        end)
 
-      refute log =~ ":ignored"
-      refute log =~ "disconnected"
+        refute log =~ ":ignored"
+        refute log =~ "disconnected"
 
-      # connection still usable
-      assert {:ok, _} = Bolty.query(pool, "RETURN 1 AS n")
-
-      Bolty.query(pool, "DROP CONSTRAINT FOR (n:#{label}) REQUIRE n.k IS UNIQUE")
+        # connection still usable
+        assert {:ok, _} = Bolty.query(pool, "RETURN 1 AS n")
+      after
+        Bolty.query(pool, "DROP CONSTRAINT #{label} IF EXISTS")
+      end
     end
   end
 

--- a/test/bolty/types_test.exs
+++ b/test/bolty/types_test.exs
@@ -5,6 +5,7 @@ defmodule Bolty.TypesTest do
   use ExUnit.Case, async: true
 
   alias Bolty.Types.{DateTimeWithTZOffset, TimeWithTZOffset, Point}
+  alias Bolty.Types.{Node, Path, Relationship, UnboundRelationship}
 
   describe "TimeWithTZOffset struct:" do
     test "create/2" do
@@ -143,6 +144,52 @@ defmodule Bolty.TypesTest do
       }
 
       assert {:error, ^point} = Point.format_param(point)
+    end
+  end
+
+  describe "Path.graph/1 (#55)" do
+    test "returns bound Relationship structs that carry their start/end endpoints" do
+      nodes = [
+        %Node{id: 100, labels: ["A"], properties: %{}},
+        %Node{id: 200, labels: ["B"], properties: %{}},
+        %Node{id: 300, labels: ["C"], properties: %{}}
+      ]
+
+      rels = [
+        %UnboundRelationship{id: 10, type: "KNOWS", properties: %{}},
+        %UnboundRelationship{id: 20, type: "KNOWS", properties: %{}}
+      ]
+
+      # A -> B -> C, both relationships traversed forward.
+      path = %Path{nodes: nodes, relationships: rels, sequence: [1, 1, 2, 2]}
+
+      assert [
+               %Node{id: 100},
+               %Relationship{id: 10, type: "KNOWS", start: 100, end: 200},
+               %Node{id: 200},
+               %Relationship{id: 20, type: "KNOWS", start: 200, end: 300},
+               %Node{id: 300}
+             ] = Path.graph(path)
+    end
+
+    test "encodes relationship direction independently of traversal (reverse edge)" do
+      nodes = [
+        %Node{id: 100, labels: ["A"], properties: %{}},
+        %Node{id: 200, labels: ["B"], properties: %{}}
+      ]
+
+      rels = [%UnboundRelationship{id: 10, type: "KNOWS", properties: %{}}]
+
+      # Walk A -> B across a relationship pointing B -> A; Neo4j encodes the
+      # reverse step as -1, surfaced as 255 by the unpacker. The relationship's
+      # own direction (start 200, end 100) is preserved, opposite the walk.
+      path = %Path{nodes: nodes, relationships: rels, sequence: [255, 1]}
+
+      assert [
+               %Node{id: 100},
+               %Relationship{id: 10, start: 200, end: 100},
+               %Node{id: 200}
+             ] = Path.graph(path)
     end
   end
 end


### PR DESCRIPTION
Fixes #55.

## Problem

`Path.graph/1` rebuilds the walk and computes each relationship's `:start`/`:end`, but it built an `UnboundRelationship` — whose struct (`use Entity, type: nil, element_id: nil`) has **no** `:start`/`:end` fields. `struct/2` silently drops unknown keys, so the returned relationships carried no endpoints or direction, making `graph/1`'s output unusable for reconstructing connectivity (the ash_neo4j Path → flowchart case).

## Fix

`graph/1` produces *bound* relationships (their endpoints are known from the traversal), so it now returns `%Relationship{}`, which carries `:start`/`:end`. The wire-level `UnboundRelationship` (built by the unpacker, endpoint-less by Bolt definition) is unchanged, and the JSON encoder already handles `Relationship`.

For `A→B→C`:
```elixir
[%Node{id: 100}, %Relationship{id: 10, start: 100, end: 200}, %Node{id: 200},
 %Relationship{id: 20, start: 200, end: 300}, %Node{id: 300}]
```

## Tests

`graph/1` had no coverage before. Added forward-endpoint and reverse-direction (255/-1 encoding) unit tests.

**Second commit (test-only):** stabilizes the #54 constraint-recovery test, which the matrix flagged as flaky — its cleanup used the 4.x `DROP CONSTRAINT FOR (n:L) REQUIRE …` form (errors on 5.x, swallowed by non-bang `query`), leaking the constraint and colliding across runs on shared DBs. Now uses a named `CREATE … IF NOT EXISTS` + `DROP … IF EXISTS` in an `after`. CI's per-job fresh DBs weren't affected; local `mix test.matrix`/shared dev DBs were.

Full matrix green twice (5.0–5.8, 6.0, negotiation) on 5.26.27 and 2026.05; dialyzer 0; format clean.