### PR TITLE
docs: scope dynamic_labels to pattern position only (#53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,9 +186,11 @@ The `policy` struct is the single source of truth for version-driven behaviour i
 |---|---|---|
 | `cypher_5` | server speaks `CYPHER 5` (Neo4j ≥ 5.0) — every currently supported server | prefix queries with `CYPHER 5` |
 | `cypher_25` | server supports the `CYPHER 25` selector (Neo4j ≥ 2025.06) | `CYPHER 25` syntax |
-| `dynamic_labels` | dynamic node labels/types (Neo4j ≥ 5.26) — a strict superset of `cypher_25` | `MATCH (n:$($label))` |
+| `dynamic_labels` | dynamic labels/types in **pattern position** (Neo4j ≥ 5.26) — a Cypher 5 feature; superset of `cypher_25` | `MATCH (n:$($label))`, `CREATE (n:$($label))` |
 
 So a `5.26.x` server resolves to `dynamic_labels: true, cypher_25: false`, while a `2026.05` server has both `true`. These flags are only meaningful in the policy resolved after HELLO; they default to `false` beforehand.
+
+> **Scope of `dynamic_labels`:** it covers the **pattern-position** form only — node labels and relationship types in `MATCH`/`CREATE`/`MERGE`. The `WHERE n:$(expr)` label-**predicate** form is a separate **Cypher 25** feature: gate it on `cypher_25`, not `dynamic_labels`. (It errors under `CYPHER 5` even on a `2026.x` server, and is unsupported on `5.26.x`.)
 
 ### Restricting the negotiated version
 

--- a/lib/bolty/policy.ex
+++ b/lib/bolty/policy.ex
@@ -43,11 +43,17 @@ defmodule Bolty.Policy do
   #     explicitly now that newer servers default to Cypher 25.
   #   * cypher_25 — server supports the `CYPHER 25` language selector
   #     (Neo4j >= 2025.06).
-  #   * dynamic_labels — server supports dynamic node labels/types
-  #     (`MATCH (n:$(expr))`), which landed in Cypher 5.26 and every calendar
-  #     release after. A strict superset of cypher_25: runs under plain
-  #     `CYPHER 5`, so a 5.26.x server has dynamic_labels: true but
-  #     cypher_25: false.
+  #   * dynamic_labels — server supports dynamic node labels/types in *pattern
+  #     position* (`MATCH (n:$(expr))`, `CREATE`/`MERGE`, dynamic relationship
+  #     types). A Cypher 5 feature that landed in 5.26 and every calendar release
+  #     after; it runs under plain `CYPHER 5`, so the set of servers with
+  #     dynamic_labels is a strict superset of those with cypher_25 (a 5.26.x
+  #     server has dynamic_labels: true but cypher_25: false).
+  #
+  #     This flag covers the pattern-position form ONLY. The `WHERE n:$(expr)`
+  #     label *predicate* form is a separate Cypher 25 language feature — gate it
+  #     on cypher_25, not dynamic_labels. It errors under `CYPHER 5` even on a
+  #     server that supports Cypher 25, and is unsupported on 5.26.x.
   @type t :: %__MODULE__{
           datetime: datetime(),
           notifications_field: notifications_field(),

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -268,7 +268,7 @@ Policy is the driver's own distillation of negotiated facts about how Bolt and t
 
 - `:cypher_5` — server speaks `CYPHER 5` (Neo4j ≥ 5.0).
 - `:cypher_25` — server supports the `CYPHER 25` selector (Neo4j ≥ 2025.06).
-- `:dynamic_labels` — dynamic node labels/types (Neo4j ≥ 5.26); a strict superset of `:cypher_25`.
+- `:dynamic_labels` — dynamic labels/types in **pattern position** (`MATCH (n:$(expr))`, `CREATE`/`MERGE`, relationship types); a Cypher 5 feature (Neo4j ≥ 5.26), a strict superset of `:cypher_25`. Covers the pattern form only — the `WHERE n:$(expr)` label-**predicate** form is a separate **Cypher 25** feature, gated on `:cypher_25` (errors under `CYPHER 5` even where Cypher 25 is supported; unsupported on `5.26.x`).
 
 To add a dimension: add the field to `Bolty.Policy`, extend `Bolty.Policy.Resolver` with a pure `put_*/3` clause, and dispatch the relevant codec/behaviour on it — do **not** bypass the boundary by reading a version number directly. Remember to update the docs too: the README "Negotiated capabilities" section and §11/§14 here.
 


### PR DESCRIPTION
Fixes #53.

## What

`%Bolty.Policy{}`'s single `dynamic_labels` boolean reads as "all dynamic-label syntax", but it only tracks the **pattern-position** form (`MATCH (n:$(expr))`, `CREATE`/`MERGE`, dynamic relationship types) — a **Cypher 5** feature available on Neo4j ≥ 5.26. The `WHERE n:$(expr)` label-**predicate** form is a separate capability that fails on 5.26.x.

## Finding (resolves the issue's open question)

Probed with explicit Cypher-language prefixes — the predicate form is a **Cypher 25 language feature**, not a separately-versioned server capability:

| server | `WHERE n:$(l)` plain | `CYPHER 5 … WHERE n:$(l)` | `CYPHER 25 … WHERE n:$(l)` |
|---|---|---|---|
| 5.26.27 (`cypher_25: false`) | ❌ SyntaxError | ❌ | ❌ |
| 2026.05 (`cypher_25: true`) | ✅ | ❌ **SyntaxError** | ✅ |

It errors under `CYPHER 5` even on a server that supports it, so its floor is **exactly `cypher_25`'s** (Neo4j ≥ 2025.06). The existing `cypher_25` flag already tells a consumer whether the predicate form is available — **no new flag is warranted** (it would just duplicate `cypher_25`).

## Change (docs-only)

- `policy.ex` `dynamic_labels` docstring: pattern-position only; predicate form → gate on `cypher_25`.
- README "Negotiated capabilities" table + a scope note.
- `usage-rules.md` §14.

No resolver/flag/behaviour change. The resolver tests already lock the boundaries (5.26 → `dynamic_labels: true, cypher_25: false`; ≥ 2025.06 → both). `dev` discussion chose docs-only over a companion flag. Issue relabelled `bug` → `documentation`.