### PR TITLE
ci: cover Bolt 6.0 (2026.05) and Bolt 5.x fallback (#65)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,16 +52,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        boltVersion:
-          - '5.0'
-          - '5.1'
-          - '5.2'
-          - '5.3'
-          - '5.4'
-          - '5.6'
-          - '5.7'
-          - '5.8'
+        # Pure include-list: each entry is one job, so the same Bolt version can run
+        # against two servers (e.g. 5.8 vs the LTS and vs the Bolt-6 server) without
+        # the matrix key colliding. mixTestPartition just uniquely names each job's
+        # coverage artifact.
         include:
+          # Bolt 5.x against the Neo4j 5.26.27 LTS.
           - boltVersion: '5.0'
             db: neo4j:5.26.27-community
             mixTestPartition: 1
@@ -86,6 +82,19 @@ jobs:
           - boltVersion: '5.8'
             db: neo4j:5.26.27-community
             mixTestPartition: 8
+          # Bolt 6.0 against Neo4j 2026.05.
+          - boltVersion: '6.0'
+            db: neo4j:2026.05-community
+            mixTestPartition: 9
+          # Bolt 5.x fallback against the Bolt-6 server (2026.05): a 5.x-constrained
+          # client must still negotiate and run against a newer server. Cover the
+          # negotiation floor (5.0) and ceiling (5.8).
+          - boltVersion: '5.8'
+            db: neo4j:2026.05-community
+            mixTestPartition: 10
+          - boltVersion: '5.0'
+            db: neo4j:2026.05-community
+            mixTestPartition: 11
     env:
       MIX_ENV: test
       BOLT_VERSIONS: ${{matrix.boltVersion}}


### PR DESCRIPTION
Fixes #65. Split out of #61 so Bolt 6 coverage lands first.

## Problem

CI tested only **Bolt 5.0–5.8 against `neo4j:5.26.27`**. Bolt 6.0 / 2026.x was verified only by the local `mix test.matrix`, so 6.0 regressions and the **5.x-client-against-a-Bolt-6-server fallback** path were never exercised in CI (recent fixes #57/#58/#55 were CI-tested on 5.x only).

## Change

- Restructure the test matrix into a **pure `include`-list** so one Bolt version can target two servers without the matrix key colliding (e.g. `5.8` vs the LTS *and* vs the Bolt-6 server).
- Add three jobs against **`neo4j:2026.05-community`**:
  - **Bolt 6.0** (native).
  - **Bolt 5.x fallback** at the negotiation **floor (5.0)** and **ceiling (5.8)** — a 5.x-constrained client negotiating against the newer server.
- The coverage job already globs `coverdata-*` partitions, so no change there.

11 test jobs total (8 LTS + 3 against 2026.05).

## Verification

Held the ground before wiring this: ran the full suite locally against **2026.05** for **every** Bolt version (5.0–5.8 and 6.0), **twice** — 18/18 green, no flakes. This PR's own CI run then proves the config end-to-end against the real 2026.05 container.

Uses **2026.05** to match the current `docker-compose.yml`; **#61** will swap the calendar image to 2026.06.