### PR TITLE
chore: group dependabot updates to reduce PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]


### PR DESCRIPTION
Groups Dependabot updates so weekly runs open one PR per ecosystem instead of one per package:

- **mix**: development dependencies grouped together (`credo`, `dialyxir`, `ex_doc`, `benchee`, etc.)
- **github-actions**: all action bumps grouped together

## Why
Recent cleanup removed a batch of stale, individually-opened Dependabot branches that had drifted well behind `dev`. Grouping reduces future PR churn and makes dependency bumps easier to review and merge as a unit.

No runtime impact — config-only change under `.github/`.