### PR TITLE
fix: correct inverted TLS verification and stop overriding user ssl_opts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,60 @@ jobs:
           name: coverdata-${{ github.run_id }}-${{matrix.mixTestPartition}}
           path: cover
           retention-days: 1
+  tls:
+    name: TLS verification (bolt+s / bolt+ssc)
+    runs-on: ubuntu-latest
+    needs: lint
+    env:
+      MIX_ENV: test
+      BOLT_TCP_PORT: 7687
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Build a TLS-enabled Neo4j whose server cert is signed by a throwaway CA,
+      # then run the :tls suite (excluded by default) against it. Guards #69's
+      # certificate handling end-to-end, which the unit tests can't observe.
+      - name: Generate TLS test certs
+        run: ./test/tls/gen_certs.sh
+
+      - name: Build TLS-enabled Neo4j image
+        run: docker build -t bolty-neo4j-tls test/tls
+
+      - name: Start Neo4j (TLS)
+        run: |
+          docker run --name neo4j-tls -p 7687:7687 \
+            -e NEO4J_AUTH=neo4j/password \
+            -e NEO4J_dbms_connector_bolt_listen__address=:7687 \
+            --detach bolty-neo4j-tls
+
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: '29.0.2'
+          elixir-version: '1.20.2'
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-mix-'1.20.2'-'29.0.2'-${{ hashFiles('**/mix.lock') }}
+
+      - run: mix deps.get
+      - run: mix deps.compile
+
+      - name: Wait for Neo4j to be ready
+        run: |
+          for i in $(seq 1 60); do
+            if docker exec neo4j-tls cypher-shell -u neo4j -p password 'RETURN 1' >/dev/null 2>&1; then
+              echo "Neo4j is ready"; exit 0
+            fi
+            sleep 3
+          done
+          echo "Neo4j did not become ready in time"; docker logs neo4j-tls; exit 1
+
+      - name: Run TLS tests
+        run: mix test --include tls test/bolty/tls_test.exs
   coverage:
     name: Coverage
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ __pycache__
 # agent related
 .agent-notes/
 .claude
+
+# generated TLS test certs (regenerate via test/tls/gen_certs.sh)
+/test/tls/certs/

--- a/README.md
+++ b/README.md
@@ -134,16 +134,30 @@ iex> Bolty.query!(Bolt, "return 1 as n") |> Bolty.Response.first()
 
 ### URI schemes
 
-By default the scheme is `bolt+s`
+By default the scheme is `bolt+s`, which performs full certificate verification.
 
-| URI        | Description                                | TLSOptions              |
-|------------|--------------------------------------------|-------------------------|
-| neo4j      | Unsecured                                  | []                      |
-| neo4j+s    | Secured with full certificate              | [verify: :verify_none]  |
-| neo4j+ssc  | Secured with self-signed certificate       | [verify: :verify_peer]  |
-| bolt       | Unsecured                                  | []                      |
-| bolt+s     | Secured with full certificate              | [verify: :verify_none]  |
-| bolt+ssc   | Secured with self-signed certificate       | [verify: :verify_peer]  |
+| URI        | Description                            | Default TLS behaviour                                             |
+|------------|---------------------------------------|------------------------------------------------------------------|
+| neo4j      | Unsecured                             | no TLS                                                            |
+| neo4j+s    | Secured, full certificate verification | `verify: :verify_peer` against the system CA store, with SNI + hostname verification |
+| neo4j+ssc  | Secured, self-signed / trust-all      | `verify: :verify_none` (encryption only, no verification)        |
+| bolt       | Unsecured                             | no TLS                                                            |
+| bolt+s     | Secured, full certificate verification | `verify: :verify_peer` against the system CA store, with SNI + hostname verification |
+| bolt+ssc   | Secured, self-signed / trust-all      | `verify: :verify_none` (encryption only, no verification)        |
+
+The `+s` defaults use the OS trust store via `:public_key.cacerts_get/0`, which
+verifies Neo4j Aura and other public-CA certificates out of the box. In a minimal
+container without an OS trust store, add [`castore`](https://hex.pm/packages/castore)
+and pass `ssl_opts: [cacertfile: CAStore.file_path()]`.
+
+Any `:ssl_opts` you pass are merged **over** these defaults, so you can override
+verification (e.g. `ssl_opts: [verify: :verify_none]` for local development) or
+point at a private CA (`ssl_opts: [cacertfile: "..."]`).
+
+> **Changed in 0.3.0:** `+s`/`+ssc` verification was previously inverted, and
+> `+s` did no server authentication. `+s` now verifies by default, and explicit
+> `:ssl_opts` are no longer silently overridden. Pin `0.2.1` if you depend on the
+> old behaviour.
 
 ## Negotiated capabilities
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 services:
+  # Neo4j 5.26 LTS with bolt TLS enabled (server cert + SSL policy baked into the
+  # image via test/tls). tls_level OPTIONAL keeps plaintext `bolt://` working
+  # (the existing suite and the healthcheck) while `bolt+s`/`bolt+ssc` exercise
+  # the TLS paths on 7687. Requires `./test/tls/gen_certs.sh` before build.
   neo4j-bolt5:
-    image: neo4j:5.26.27
+    build:
+      context: ./test/tls
+      args:
+        NEO4J_VERSION: "5.26.28"
     container_name: neo4j-ash-bolt5
     ports:
       - "7687:7687"

--- a/lib/bolty/client.ex
+++ b/lib/bolty/client.ex
@@ -44,13 +44,14 @@ defmodule Bolty.Client do
       :socket_options,
       :versions,
       :ssl?,
+      :tls_verify,
       :ssl_opts
     ]
 
     def new(opts) do
       {hostname, port} = get_hostname_and_port(opts)
       {username, password} = get_user_and_pass(opts)
-      {scheme, ssl?, ssl_opts} = get_scheme_and_ssl_opts(opts)
+      {scheme, ssl?, tls_verify, ssl_opts} = get_scheme_and_ssl_opts(opts)
       versions = get_versions(opts)
 
       %__MODULE__{
@@ -64,26 +65,39 @@ defmodule Bolty.Client do
           Keyword.merge([mode: :binary, packet: :raw, active: false], opts[:socket_options] || []),
         versions: versions,
         ssl?: ssl?,
+        tls_verify: tls_verify,
         ssl_opts: ssl_opts
       }
     end
 
+    # Maps the connection scheme to a TLS *intent*, not materialised ssl options:
+    # the strict defaults (incl. SNI, which needs the hostname) are built at
+    # connect time in Client.maybe_connect_to_ssl/2. Per Neo4j scheme semantics
+    # (matching the official drivers):
+    #
+    #   * bolt / neo4j        -> no TLS
+    #   * bolt+s / neo4j+s    -> full verification (verify_peer against system CAs)
+    #   * bolt+ssc / neo4j+ssc -> self-signed / trust-all (encrypt only, no verify)
+    #
+    # User-supplied :ssl_opts are returned raw and merged *over* the strict
+    # defaults at connect time, so an explicit `verify:`/`cacertfile:` always wins.
     defp get_scheme_and_ssl_opts(opts) do
       scheme = get_schema(opts)
       ssl_opts = Keyword.get(opts, :ssl_opts, [])
 
-      {ssl, ssl_config} =
+      {ssl?, tls_verify} =
         case scheme do
-          "bolt" -> {false, ssl_opts}
-          "neo4j" -> {false, ssl_opts}
-          "neo4j+s" -> {true, Keyword.merge(ssl_opts, verify: :verify_none)}
-          "bolt+s" -> {true, Keyword.merge(ssl_opts, verify: :verify_none)}
-          "neo4j+ssc" -> {true, Keyword.merge(ssl_opts, verify: :verify_peer)}
-          "bolt+ssc" -> {true, Keyword.merge(ssl_opts, verify: :verify_peer)}
-          _ -> {true, ssl_opts}
+          "bolt" -> {false, :none}
+          "neo4j" -> {false, :none}
+          "bolt+s" -> {true, :verify}
+          "neo4j+s" -> {true, :verify}
+          "bolt+ssc" -> {true, :self_signed}
+          "neo4j+ssc" -> {true, :self_signed}
+          # Unknown scheme: secure by default.
+          _ -> {true, :verify}
         end
 
-      {scheme, ssl, ssl_config}
+      {scheme, ssl?, tls_verify, ssl_opts}
     end
 
     defp get_user_and_pass(opts) do
@@ -203,10 +217,11 @@ defmodule Bolty.Client do
       port: port,
       socket_options: socket_options,
       connect_timeout: connect_timeout,
+      tls_verify: tls_verify,
       ssl_opts: ssl_opts
     } = config
 
-    opts = Keyword.merge(ssl_opts, socket_options)
+    opts = build_tls_opts(tls_verify, hostname, ssl_opts, socket_options)
 
     case :ssl.connect(String.to_charlist(hostname), port, opts, connect_timeout) do
       {:ok, ssl_sock} ->
@@ -218,6 +233,59 @@ defmodule Bolty.Client do
       other ->
         other
     end
+  end
+
+  # Assembles the final :ssl.connect options. Layering (last wins): strict TLS
+  # defaults < user :ssl_opts < transport socket options. User opts override
+  # verification/CA config so an explicit `verify:`/`cacertfile:` always takes
+  # effect; transport options (mode/packet/active) are structural and stay
+  # authoritative. Public (within this @moduledoc false module) so the
+  # precedence can be unit-tested without a live TLS server.
+  def build_tls_opts(tls_verify, hostname, ssl_opts, socket_options) do
+    tls_verify
+    |> tls_default_opts(hostname)
+    |> Keyword.merge(ssl_opts)
+    |> put_default_cacerts()
+    |> Keyword.merge(socket_options)
+  end
+
+  # Supply the OS trust store as the default CA source for verify_peer — but only
+  # when the user hasn't provided their own. :cacerts and :cacertfile are
+  # mutually exclusive in :ssl (if both are present :cacerts wins and :cacertfile
+  # is ignored), so injecting a default :cacerts unconditionally would silently
+  # override a user's `ssl_opts: [cacertfile: ...]`. Applied after the user merge
+  # so their CA choice, and any `verify: :verify_none` override, take effect.
+  defp put_default_cacerts(opts) do
+    cond do
+      opts[:verify] != :verify_peer -> opts
+      Keyword.has_key?(opts, :cacertfile) -> opts
+      Keyword.has_key?(opts, :cacerts) -> opts
+      true -> Keyword.put(opts, :cacerts, :public_key.cacerts_get())
+    end
+  end
+
+  # Strict, secure-by-default TLS options per scheme intent. Built here (not at
+  # scheme-mapping time) because server_name_indication needs the resolved
+  # hostname. `+s` gets full CA verification + hostname check; `+ssc` is the
+  # documented self-signed / trust-all opt-out (encrypt only). Callers can still
+  # override any of these via :ssl_opts, which are merged on top. The CA source
+  # for :verify is added separately by put_default_cacerts/1.
+  defp tls_default_opts(:verify, hostname) do
+    [
+      verify: :verify_peer,
+      depth: 3,
+      server_name_indication: String.to_charlist(hostname),
+      customize_hostname_check: [
+        match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+      ]
+    ]
+  end
+
+  defp tls_default_opts(:self_signed, hostname) do
+    [
+      verify: :verify_none,
+      server_name_indication: String.to_charlist(hostname)
+    ]
   end
 
   defp handshake(client, config) do

--- a/test/bolty/client_test.exs
+++ b/test/bolty/client_test.exs
@@ -92,36 +92,111 @@ defmodule Bolty.ClientTest do
       assert config.username == "usertests"
     end
 
-    test "returns correct values for different schemes" do
+    test "maps schemes to the correct TLS verification intent" do
       base_opts = [
         auth: [username: "usertests"]
       ]
 
       opts1 = base_opts ++ [scheme: "bolt"]
-      assert %Client.Config{scheme: "bolt", ssl?: false, ssl_opts: []} = Client.Config.new(opts1)
 
+      assert %Client.Config{scheme: "bolt", ssl?: false, tls_verify: :none} =
+               Client.Config.new(opts1)
+
+      # +s -> full verification (previously, and incorrectly, :verify_none)
       opts2 = base_opts ++ [scheme: "bolt+s"]
 
-      assert %Client.Config{scheme: "bolt+s", ssl?: true, ssl_opts: [verify: :verify_none]} =
+      assert %Client.Config{scheme: "bolt+s", ssl?: true, tls_verify: :verify} =
                Client.Config.new(opts2)
 
+      # +ssc -> self-signed / trust-all (previously, and incorrectly, :verify_peer)
       opts3 = base_opts ++ [scheme: "bolt+ssc"]
 
-      assert %Client.Config{scheme: "bolt+ssc", ssl?: true, ssl_opts: [verify: :verify_peer]} =
+      assert %Client.Config{scheme: "bolt+ssc", ssl?: true, tls_verify: :self_signed} =
                Client.Config.new(opts3)
 
       opts4 = base_opts ++ [scheme: "neo4j"]
-      assert %Client.Config{scheme: "neo4j", ssl?: false, ssl_opts: []} = Client.Config.new(opts4)
+
+      assert %Client.Config{scheme: "neo4j", ssl?: false, tls_verify: :none} =
+               Client.Config.new(opts4)
 
       opts5 = base_opts ++ [scheme: "neo4j+s"]
 
-      assert %Client.Config{scheme: "neo4j+s", ssl?: true, ssl_opts: [verify: :verify_none]} =
+      assert %Client.Config{scheme: "neo4j+s", ssl?: true, tls_verify: :verify} =
                Client.Config.new(opts5)
 
       opts6 = base_opts ++ [scheme: "neo4j+ssc"]
 
-      assert %Client.Config{scheme: "neo4j+ssc", ssl?: true, ssl_opts: [verify: :verify_peer]} =
+      assert %Client.Config{scheme: "neo4j+ssc", ssl?: true, tls_verify: :self_signed} =
                Client.Config.new(opts6)
+    end
+
+    test "preserves user-supplied :ssl_opts verbatim (no override at config time)" do
+      opts = [
+        auth: [username: "usertests"],
+        scheme: "bolt+s",
+        ssl_opts: [verify: :verify_peer, cacertfile: "/etc/ssl/my_ca.pem"]
+      ]
+
+      # The strict defaults are materialised at connect time; Config keeps the
+      # user's opts raw so they can be merged *over* the defaults (user wins).
+      assert %Client.Config{
+               tls_verify: :verify,
+               ssl_opts: [verify: :verify_peer, cacertfile: "/etc/ssl/my_ca.pem"]
+             } = Client.Config.new(opts)
+    end
+  end
+
+  describe "build_tls_opts/4" do
+    @describetag :core
+    @socket_opts [mode: :binary, packet: :raw, active: false]
+
+    test ":verify builds strict, secure-by-default TLS options" do
+      opts = Client.build_tls_opts(:verify, "graph.example.com", [], @socket_opts)
+
+      assert opts[:verify] == :verify_peer
+      assert opts[:server_name_indication] == ~c"graph.example.com"
+      assert opts[:customize_hostname_check] == [
+               match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+             ]
+      # CA trust anchors sourced from the OS store, not an empty/absent list.
+      assert is_list(opts[:cacerts]) and opts[:cacerts] != []
+    end
+
+    test ":self_signed encrypts without verification" do
+      opts = Client.build_tls_opts(:self_signed, "localhost", [], @socket_opts)
+
+      assert opts[:verify] == :verify_none
+      assert opts[:server_name_indication] == ~c"localhost"
+      refute Keyword.has_key?(opts, :cacerts)
+    end
+
+    test "user :ssl_opts override the strict defaults (user wins)" do
+      user = [verify: :verify_none, cacertfile: "/etc/ssl/my_ca.pem"]
+      opts = Client.build_tls_opts(:verify, "graph.example.com", user, @socket_opts)
+
+      # The security-critical guarantee: an explicit user override is honoured
+      # rather than being silently forced back to the default.
+      assert opts[:verify] == :verify_none
+      assert opts[:cacertfile] == "/etc/ssl/my_ca.pem"
+    end
+
+    test "a user :cacertfile is honoured, not clobbered by the default :cacerts" do
+      # :cacerts and :cacertfile are mutually exclusive in :ssl (:cacerts wins);
+      # injecting the default OS trust store unconditionally would silently
+      # ignore the user's CA file. verify stays :verify_peer here.
+      user = [cacertfile: "/etc/ssl/my_ca.pem"]
+      opts = Client.build_tls_opts(:verify, "graph.example.com", user, @socket_opts)
+
+      assert opts[:verify] == :verify_peer
+      assert opts[:cacertfile] == "/etc/ssl/my_ca.pem"
+      refute Keyword.has_key?(opts, :cacerts)
+    end
+
+    test "transport socket options stay authoritative over user :ssl_opts" do
+      user = [mode: :something_else]
+      opts = Client.build_tls_opts(:verify, "graph.example.com", user, @socket_opts)
+
+      assert opts[:mode] == :binary
     end
   end
 

--- a/test/bolty/client_test.exs
+++ b/test/bolty/client_test.exs
@@ -155,9 +155,11 @@ defmodule Bolty.ClientTest do
 
       assert opts[:verify] == :verify_peer
       assert opts[:server_name_indication] == ~c"graph.example.com"
+
       assert opts[:customize_hostname_check] == [
                match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
              ]
+
       # CA trust anchors sourced from the OS store, not an empty/absent list.
       assert is_list(opts[:cacerts]) and opts[:cacerts] != []
     end

--- a/test/bolty/tls_test.exs
+++ b/test/bolty/tls_test.exs
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Bolty.TLSTest do
+  @moduledoc """
+  End-to-end TLS verification tests against the TLS-enabled `neo4j-bolt5`
+  compose service (port 7687), whose server certificate is signed by the
+  throwaway CA in test/tls/certs/ca.crt.
+
+  Excluded by default. To run:
+
+      ./test/tls/gen_certs.sh
+      docker compose up -d --build neo4j-bolt5
+      mix test --include tls test/bolty/tls_test.exs
+  """
+  use ExUnit.Case, async: false
+
+  @moduletag :tls
+
+  alias Bolty.Client
+
+  @host "localhost"
+  @port 7687
+  @ca_path Path.join([__DIR__, "..", "tls", "certs", "ca.crt"]) |> Path.expand()
+
+  defp base_opts do
+    [
+      hostname: @host,
+      port: @port,
+      auth: [username: "neo4j", password: "password"],
+      user_agent: "boltyTest/1"
+    ]
+  end
+
+  describe "bolt+s (full verification)" do
+    test "connects when the signing CA is trusted via ssl_opts" do
+      opts = [scheme: "bolt+s", ssl_opts: [cacertfile: @ca_path]] ++ base_opts()
+
+      assert {:ok, client} = Client.connect(opts)
+      assert is_float(client.bolt_version)
+    end
+
+    test "fails against the OS trust store (server CA is unknown)" do
+      # No cacertfile override, so the strict defaults verify against the system
+      # trust store, which does not contain our throwaway CA. This proves +s
+      # actually enforces verification rather than silently accepting any cert.
+      opts = [scheme: "bolt+s"] ++ base_opts()
+
+      assert {:error, _reason} = Client.connect(opts)
+    end
+
+    test "fails when the presented hostname does not match the certificate" do
+      # Cert SANs are localhost / 127.0.0.1; connect by an unmatched name.
+      opts =
+        [scheme: "bolt+s", hostname: "not-in-cert.example", ssl_opts: [cacertfile: @ca_path]] ++
+          Keyword.delete(base_opts(), :hostname)
+
+      assert {:error, _reason} = Client.connect(opts)
+    end
+  end
+
+  describe "bolt+ssc (self-signed / trust-all)" do
+    test "connects without trusting the CA (verify_none)" do
+      opts = [scheme: "bolt+ssc"] ++ base_opts()
+
+      assert {:ok, client} = Client.connect(opts)
+      assert is_float(client.bolt_version)
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -9,7 +9,10 @@ exclude = [
   :skip,
   :bench,
   :apoc,
-  :legacy
+  :legacy,
+  # TLS integration tests need the TLS-enabled neo4j-bolt5 service (port 7687)
+  # and generated certs; run explicitly with `mix test --include tls`.
+  :tls
 ]
 
 include = [:core]

--- a/test/tls/Dockerfile
+++ b/test/tls/Dockerfile
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Neo4j 5.26 LTS with a baked-in bolt server certificate, used by the
+# neo4j-bolt5 compose service for the TLS integration tests. Certs are generated
+# on the host by test/tls/gen_certs.sh and copied in here so they carry the
+# ownership + 0600 permissions Neo4j requires (baking avoids the bind-mount
+# permission failures you hit mounting a host-owned private key).
+ARG NEO4J_VERSION=5.26.28
+FROM neo4j:${NEO4J_VERSION}
+
+COPY certs/server.crt /ssl/bolt/public.crt
+COPY certs/server.key /ssl/bolt/private.key
+
+RUN mkdir -p /ssl/bolt/trusted /ssl/bolt/revoked \
+ && chown -R neo4j:neo4j /ssl \
+ && chmod 600 /ssl/bolt/private.key \
+ && chmod 644 /ssl/bolt/public.crt
+
+# Bolt SSL policy, baked into the image so compose and CI's `docker run` both get
+# it without repeating the env. tls_level OPTIONAL keeps plaintext bolt working
+# (existing suite + healthcheck) while bolt+s / bolt+ssc exercise TLS.
+ENV NEO4J_dbms_ssl_policy_bolt_enabled=true \
+    NEO4J_dbms_ssl_policy_bolt_base__directory=/ssl/bolt \
+    NEO4J_dbms_ssl_policy_bolt_private__key=private.key \
+    NEO4J_dbms_ssl_policy_bolt_public__certificate=public.crt \
+    NEO4J_dbms_ssl_policy_bolt_client__auth=NONE \
+    NEO4J_server_bolt_tls__level=OPTIONAL

--- a/test/tls/gen_certs.sh
+++ b/test/tls/gen_certs.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Generates a throwaway local CA and a Neo4j bolt server certificate for the
+# TLS integration tests (test/bolty/tls_test.exs) and the TLS-enabled
+# neo4j-bolt5 compose service. NOT for production use. Output lands in
+# test/tls/certs/ and is git-ignored — regenerate with `./test/tls/gen_certs.sh`.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/certs"
+mkdir -p "$DIR"
+cd "$DIR"
+
+# 1. Local CA (the test trusts this via ssl_opts: [cacertfile: "ca.crt"]).
+openssl req -x509 -newkey rsa:4096 -nodes \
+  -keyout ca.key -out ca.crt -days 3650 \
+  -subj "/CN=bolty-test-ca" 2>/dev/null
+
+# 2. Server key + CSR.
+openssl req -newkey rsa:2048 -nodes \
+  -keyout server.key -out server.csr \
+  -subj "/CN=localhost" 2>/dev/null
+
+# 3. Sign the server cert, with SANs so hostname verification passes whether the
+#    client connects to "localhost" or "127.0.0.1".
+openssl x509 -req -in server.csr \
+  -CA ca.crt -CAkey ca.key -CAcreateserial \
+  -out server.crt -days 825 \
+  -extfile <(printf "subjectAltName=DNS:localhost,IP:127.0.0.1\nbasicConstraints=CA:FALSE\nkeyUsage=digitalSignature,keyEncipherment\nextendedKeyUsage=serverAuth") \
+  2>/dev/null
+
+rm -f server.csr ca.srl
+echo "TLS test certs written to $DIR (ca.crt, server.crt, server.key)"


### PR DESCRIPTION
Fixes #69 (P0, 0.3.0 breaking batch).

## Problem
The scheme→SSL mapping was **inverted** vs Neo4j's own semantics: `bolt+s`/`neo4j+s` (full verification) mapped to `verify_none` while `+ssc` (self-signed) mapped to `verify_peer`. Since `bolt+s` is the default scheme, connections got TLS with **no server authentication** — a silent MITM exposure. The mapping also merged `verify: :verify_none` **over** user-supplied `ssl_opts`, discarding an explicit `verify_peer`.

## Fix
- Map each scheme to a TLS **intent** (`:none | :verify | :self_signed`); materialise strict options at connect time (where the hostname is available for SNI):
  - `+s`/`neo4j+s` → `verify_peer` against the OS trust store (`:public_key.cacerts_get/0`, verifies Aura out of the box) + SNI + https hostname check
  - `+ssc`/`neo4j+ssc` → `verify_none` (self-signed / trust-all, encrypt only)
- User `:ssl_opts` merge **over** the defaults (user wins); transport socket opts stay authoritative
- `put_default_cacerts/1` only injects the OS trust store when verifying **and** the user hasn't supplied a CA (`cacerts`/`cacertfile` are mutually exclusive in `:ssl` — this was caught by the live rig)

## Test rig (neo4j 5.26.28)
A TLS-enabled Neo4j (`test/tls`, certs baked into the image) exercises the paths end-to-end. `test/bolty/tls_test.exs` (tagged `:tls`, excluded by default): verified connect via trusted CA, unknown-CA rejection, hostname-mismatch rejection, `+ssc` connect. A new CI `tls` job runs it.

## Verification
11 unit + 4 TLS-integration + 35 plaintext tests pass; dialyzer clean.

## BREAKING CHANGE
`bolt+s`/`neo4j+s` now verify the server certificate by default and explicit `ssl_opts` are no longer overridden. Pin `0.2.1` to keep the previous `verify_none` behaviour.

## Consumer safety
`ash_neo4j` does not touch TLS config — no coupling impact.