### PR TITLE
ci: bump Neo4j 5.26 LTS to 5.26.28 in the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,30 +57,30 @@ jobs:
         # the matrix key colliding. mixTestPartition just uniquely names each job's
         # coverage artifact.
         include:
-          # Bolt 5.x against the Neo4j 5.26.27 LTS.
+          # Bolt 5.x against the Neo4j 5.26.28 LTS.
           - boltVersion: '5.0'
-            db: neo4j:5.26.27-community
+            db: neo4j:5.26.28-community
             mixTestPartition: 1
           - boltVersion: '5.1'
-            db: neo4j:5.26.27-community
+            db: neo4j:5.26.28-community
             mixTestPartition: 2
           - boltVersion: '5.2'
-            db: neo4j:5.26.27-community
+            db: neo4j:5.26.28-community
             mixTestPartition: 3
           - boltVersion: '5.3'
-            db: neo4j:5.26.27-community
+            db: neo4j:5.26.28-community
             mixTestPartition: 4
           - boltVersion: '5.4'
-            db: neo4j:5.26.27-community
+            db: neo4j:5.26.28-community
             mixTestPartition: 5
           - boltVersion: '5.6'
-            db: neo4j:5.26.27-community
+            db: neo4j:5.26.28-community
             mixTestPartition: 6
           - boltVersion: '5.7'
-            db: neo4j:5.26.27-community
+            db: neo4j:5.26.28-community
             mixTestPartition: 7
           - boltVersion: '5.8'
-            db: neo4j:5.26.27-community
+            db: neo4j:5.26.28-community
             mixTestPartition: 8
           # Bolt 6.0 against Neo4j 2026.05.
           - boltVersion: '6.0'

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ SPDX-License-Identifier: Apache-2.0
 
 `Bolty` is an Elixir driver for [Neo4j](https://neo4j.com/developer/graph-database/)/Bolt Protocol, forked from `Boltx` and now developed independently.
 
-- Supports Neo4j 5.26.27 LTS and Neo4j 2026.05
+- Supports Neo4j 5.26.28 LTS and Neo4j 2026.05
 - Supports Bolt versions: 5.0/5.1/5.2/5.3/5.4/5.6/5.7/5.8/6.0
 - Supports transactions, prepared queries, streaming, pooling and more via DBConnection
 - Automatic decoding and encoding of Elixir values
@@ -153,7 +153,7 @@ Bolty negotiates the highest mutually-supported Bolt version during connection. 
 iex> Bolty.connection_info(conn)
 %{
   bolt_version: 5.8,
-  server_version: "Neo4j/5.26.27",
+  server_version: "Neo4j/5.26.28",
   policy: %Bolty.Policy{
     datetime: :evolved,
     notifications_field: :notifications_disabled_classifications,


### PR DESCRIPTION
Closes #81.

Point the eight Bolt 5.x matrix jobs at `neo4j:5.26.28-community` (the new 5.26 LTS patch), and update the README support statement + `connection_info` example. The Bolt-6 (2026.05) jobs are unaffected.

The `5.26.28-community` tag is confirmed available on Docker Hub, and 5.26.28 was validated locally (plaintext + TLS suites pass against it).

Note: the compose `neo4j-bolt5` bump to 5.26.28 lands separately in #69's TLS rig; this PR is CI-matrix + docs only, so the two don't conflict.