### PR TITLE
chore: add shared pre-push hook for fast lint checks

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Pre-push hook: run the fast half of CI's "Code Quality Checks" (lint) job so
+# formatting and compile-warning failures are caught before they reach CI.
+#
+# Enable once per clone with `mix setup` (or `git config core.hooksPath .githooks`).
+# Bypass in a pinch with:  SKIP_HOOKS=1 git push
+set -euo pipefail
+
+if [ "${SKIP_HOOKS:-0}" = "1" ]; then
+  echo "pre-push: skipped (SKIP_HOOKS=1)"
+  exit 0
+fi
+
+echo "pre-push: mix format --check-formatted"
+mix format --check-formatted
+
+echo "pre-push: mix compile --warnings-as-errors"
+mix compile --warnings-as-errors
+
+echo "pre-push: OK"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,15 +41,16 @@ Run `mix setup` once per clone to enable the shared **pre-push hook**
 lint failures locally instead of in CI. Bypass in a pinch with
 `SKIP_HOOKS=1 git push`.
 
-## Local Neo4j — shared, handle with care
+## Local Neo4j
 
-The test databases are **shared across diffo-dev repos** (bolty and ash_neo4j run the same containers). `docker-compose.yml` is aligned with ash_neo4j:
+bolty runs its **own** test containers via `docker-compose.yml` (other diffo-dev repos start their own). Ports and creds still match ash_neo4j (`neo4j` / `password` on 7687 / 7689) so shared tooling lines up:
 
-- `neo4j-bolt5` — `neo4j:5.26.27` on **7687** (Bolt 5.x)
-- `neo4j-bolt6` — `neo4j:2026.05` on **7689** (Bolt 6.0)
-- auth `neo4j` / `password`
+- `neo4j-bolt5` — **builds** `test/tls/Dockerfile` = `neo4j:5.26.28` with **bolt TLS** (SSL policy baked into the image; `tls_level: OPTIONAL` so plaintext still works) on **7687** (Bolt 5.x). Requires `./test/tls/gen_certs.sh` first (throwaway CA + server cert, git-ignored), then `docker compose up -d --build neo4j-bolt5`.
+- `neo4j-bolt6` — `neo4j:2026.05` on **7689** (Bolt 6.0).
 
-Do **not** `docker rm` / `docker compose up --remove-orphans` against these — you may break another repo's session. Connect to what's already running. Note the suite's setup runs `MATCH (n) DETACH DELETE n`, so don't point it at a database you care about. Run the version matrix with `mix test.matrix` (`BOLT_6_TCP_PORT=7689` for the Bolt 6 server).
+Because 7687 now serves TLS, `bolt+s` / `bolt+ssc` are testable locally: `mix test --include tls` runs the `:tls` suite (`test/bolty/tls_test.exs`) against it (needs the container up + certs generated). The `:tls` tag is excluded by default.
+
+Scope docker commands to the **named service** (e.g. `docker compose up -d neo4j-bolt5`) — avoid a bare `docker compose up` / `--remove-orphans` that could sweep unrelated containers. The suite's setup runs `MATCH (n) DETACH DELETE n`, so don't point it at a database you care about. Run the version matrix with `mix test.matrix` (`BOLT_6_TCP_PORT=7689` for the Bolt 6 server).
 
 ## Policy is the source of truth — and keep its docs in sync
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,12 @@ Runs on PRs to `dev`/`main` (it once targeted a non-existent `master` and silent
 
 Every new source file needs an SPDX header (REUSE check), Apache-2.0.
 
+Run `mix setup` once per clone to enable the shared **pre-push hook**
+(`.githooks/pre-push`): it runs `mix format --check-formatted` and
+`mix compile --warnings-as-errors` before every push, catching the two cheapest
+lint failures locally instead of in CI. Bypass in a pinch with
+`SKIP_HOOKS=1 git push`.
+
 ## Local Neo4j — shared, handle with care
 
 The test databases are **shared across diffo-dev repos** (bolty and ash_neo4j run the same containers). `docker-compose.yml` is aligned with ash_neo4j:

--- a/mix.exs
+++ b/mix.exs
@@ -58,10 +58,20 @@ defmodule Bolty.Mixfile do
 
   defp aliases do
     [
+      setup: ["deps.get", &enable_git_hooks/1],
       test: [
         "test"
       ]
     ]
+  end
+
+  # Point git at the repo's shared hooks (.githooks/pre-push runs the fast lint
+  # checks before a push). Idempotent; run via `mix setup`.
+  defp enable_git_hooks(_args) do
+    case System.cmd("git", ["config", "core.hooksPath", ".githooks"], stderr_to_stdout: true) do
+      {_, 0} -> Mix.shell().info("Git hooks enabled (core.hooksPath = .githooks)")
+      {out, _} -> Mix.shell().error("Could not enable git hooks: #{out}")
+    end
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]


### PR DESCRIPTION
Catches the two cheapest CI lint failures locally, before they reach CI (prompted by the `mix format` slip that failed lint on #82), plus a docs refresh.

## Pre-push hook
- `.githooks/pre-push` runs `mix format --check-formatted` and `mix compile --warnings-as-errors` before every push.
- `mix setup` alias enables it per clone (`git config core.hooksPath .githooks`) — idempotent.
- Documented under AGENTS.md → CI. Bypass with `SKIP_HOOKS=1 git push`.

### Why pre-push (not pre-commit)
Runs once before code leaves the machine, mirroring CI's fast gates, without nagging on every commit. Dialyzer is intentionally left to CI (too slow for a hook without a warm PLT).

## AGENTS.md "Local Neo4j" refresh
The #82/#83 merges left that section stale. Updated to reflect that bolty now runs its own containers (not shared): `neo4j-bolt5` builds `neo4j:5.26.28` with bolt TLS on 7687 (needs `./test/tls/gen_certs.sh` first), the `mix test --include tls` flow, and `docker` guidance scoped to the named service instead of the obsolete shared-DB warning.

## Verified
Hook tested both paths locally (passes clean, blocks a formatting violation) and ran green on this branch's own pushes.