### PR TITLE
fix: unify the error surface to always return %Bolty.Error{}

### DIFF
--- a/lib/bolty.ex
+++ b/lib/bolty.ex
@@ -103,6 +103,12 @@ defmodule Bolty do
   @doc """
   Executes a single query and returns the result.
 
+  Returns `{:ok, %Bolty.Response{}}` on success. On failure it returns
+  `{:error, %Bolty.Error{}}` — every driver-side failure (connection, TLS,
+  version negotiation, and Neo4j server errors) is surfaced as a `Bolty.Error`,
+  so callers can match a single error shape. Pool checkout/timeout failures may
+  additionally surface as `DBConnection.ConnectionError`.
+
   ## Examples
 
   ```elixir

--- a/lib/bolty/client.ex
+++ b/lib/bolty/client.ex
@@ -203,11 +203,8 @@ defmodule Bolty.Client do
       {:ok, sock} ->
         {:ok, %{client | sock: {:gen_tcp, sock}}}
 
-      {:error, :timeout} ->
-        {:error, Bolty.Error.wrap(__MODULE__, :timeout)}
-
-      other ->
-        other
+      {:error, reason} ->
+        {:error, wrap_connect_error(reason)}
     end
   end
 
@@ -227,12 +224,25 @@ defmodule Bolty.Client do
       {:ok, ssl_sock} ->
         {:ok, %{client | sock: {:ssl, ssl_sock}}}
 
-      {:error, :timeout} ->
-        {:error, Bolty.Error.wrap(__MODULE__, :timeout)}
-
-      other ->
-        other
+      {:error, reason} ->
+        {:error, wrap_connect_error(reason)}
     end
+  end
+
+  # Normalise a raw :gen_tcp/:ssl connect error into a %Bolty.Error{}. Reasons are
+  # posix atoms (:econnrefused, :nxdomain, :timeout, …) or, for TLS, a
+  # {:tls_alert, {alert, description}} tuple — keep the alert legible so a
+  # verification failure is diagnosable. Anything else is preserved via inspect.
+  defp wrap_connect_error(reason) when is_atom(reason) do
+    Bolty.Error.wrap(__MODULE__, reason)
+  end
+
+  defp wrap_connect_error({:tls_alert, {alert, description}}) do
+    Bolty.Error.wrap(__MODULE__, %{code: :tls_alert, message: "#{alert}: #{description}"})
+  end
+
+  defp wrap_connect_error(reason) do
+    Bolty.Error.wrap(__MODULE__, %{code: :connect_error, message: inspect(reason)})
   end
 
   # Assembles the final :ssl.connect options. Layering (last wins): strict TLS
@@ -314,7 +324,7 @@ defmodule Bolty.Client do
       end
     else
       _ ->
-        {:error, "Could not negotiate the version"}
+        {:error, Bolty.Error.wrap(__MODULE__, :version_negotiation_error)}
     end
   end
 

--- a/lib/bolty/connection.ex
+++ b/lib/bolty/connection.ex
@@ -154,8 +154,14 @@ defmodule Bolty.Connection do
         recover_from_failure(client, error, state)
     end
   rescue
+    # An exception mid-execute (e.g. raised during recv after RUN was sent) can
+    # leave unread RECORD/SUCCESS bytes on the socket that would poison the next
+    # query on this pooled connection. Disconnect rather than return it to the
+    # pool, and surface a %Bolty.Error{} instead of the raw exception.
     e ->
-      {:error, e, state}
+      {:disconnect,
+       Bolty.Error.wrap(__MODULE__, %{code: :execute_exception, message: Exception.message(e)}),
+       state}
   end
 
   # A statement FAILURE leaves the Bolt connection in the protocol's FAILED state.

--- a/test/bolty/client_test.exs
+++ b/test/bolty/client_test.exs
@@ -245,6 +245,16 @@ defmodule Bolty.ClientTest do
       opts = [versions: [50]] ++ @opts
       {:error, %Bolty.Error{code: :version_negotiation_error}} = Client.connect(opts)
     end
+
+    @tag core: true
+    test "a refused connection returns a wrapped %Bolty.Error{}, not a raw posix tuple" do
+      # Nothing listens on this port, so :gen_tcp.connect returns {:error, :econnrefused};
+      # #70 requires it surface as a %Bolty.Error{} rather than the bare atom.
+      opts = [port: 65_533] ++ @opts
+
+      assert {:error, %Bolty.Error{module: Bolty.Client, code: code}} = Client.connect(opts)
+      assert is_atom(code)
+    end
   end
 
   describe "recv_packets" do

--- a/test/bolty/tls_test.exs
+++ b/test/bolty/tls_test.exs
@@ -46,16 +46,22 @@ defmodule Bolty.TLSTest do
       # actually enforces verification rather than silently accepting any cert.
       opts = [scheme: "bolt+s"] ++ base_opts()
 
-      assert {:error, _reason} = Client.connect(opts)
+      # A TLS handshake rejection surfaces as a unified %Bolty.Error{} (#70).
+      assert {:error, %Bolty.Error{code: :tls_alert}} = Client.connect(opts)
     end
 
-    test "fails when the presented hostname does not match the certificate" do
-      # Cert SANs are localhost / 127.0.0.1; connect by an unmatched name.
+    test "fails when the certificate does not match the requested hostname" do
+      # Connect to the resolvable loopback but present an SNI that isn't in the
+      # cert SANs (localhost / 127.0.0.1), so the CA validates but verify_peer's
+      # hostname check rejects it — a tls_alert, not a DNS/connect error.
       opts =
-        [scheme: "bolt+s", hostname: "not-in-cert.example", ssl_opts: [cacertfile: @ca_path]] ++
-          Keyword.delete(base_opts(), :hostname)
+        [
+          scheme: "bolt+s",
+          hostname: "127.0.0.1",
+          ssl_opts: [cacertfile: @ca_path, server_name_indication: ~c"wrong.example"]
+        ] ++ Keyword.delete(base_opts(), :hostname)
 
-      assert {:error, _reason} = Client.connect(opts)
+      assert {:error, %Bolty.Error{code: :tls_alert}} = Client.connect(opts)
     end
   end
 


### PR DESCRIPTION
Fixes #70 (P0, 0.3.0 breaking batch).

## Problem
The same code paths could hand a caller a bare string, a raw posix tuple, a `%Bolty.Error{}`, a raw exception, or a `DBConnection.ConnectionError` — no reliable `case`/`rescue` was possible.

## Fix
- **Connect leaks** — `wrap_connect_error/1` normalises `:gen_tcp`/`:ssl` failures into `%Bolty.Error{}`: posix atoms (`:econnrefused`, `:nxdomain`, `:timeout`), `{:tls_alert, {alert, desc}}` tuples (→ `code: :tls_alert` with the alert in the message), and any other term via inspect. Replaces the raw `{:error, reason}` passthrough in both connect clauses (the old explicit `:timeout` case is subsumed).
- **Bare string** — the handshake else-branch now returns `%Bolty.Error{code: :version_negotiation_error}` (matching the `+0.0` path).
- **execute/4 rescue** — `{:error, raw_exception, state}` → `{:disconnect, %Bolty.Error{}, state}`. An exception mid-recv (after RUN was sent) can leave unread bytes that poison the next pooled query, so drop the connection; mirrors `recover_from_failure/2`.
- **Docs** — `Bolty.query/4` now documents the `{:ok, Response} | {:error, Bolty.Error}` contract. (Full `@spec` rollout stays in #77.)

## Tests
- New offline unit test: a refused connection returns `%Bolty.Error{}`, not a raw posix tuple.
- Tightened the TLS suite to assert `%Bolty.Error{code: :tls_alert}` on verification failures — which surfaced that the old hostname-mismatch test was really hitting `:nxdomain` (DNS), so it's rewritten to genuinely exercise hostname verification via an SNI override.
- 280 plaintext tests + 4 TLS tests pass; dialyzer clean.

## Consumer safety
`%Bolty.Error{}` keeps its `.bolt = %{code, message}` shape, so `ash_neo4j`'s `Error.Neo4j.from_bolt/1` is unaffected — its string/posix fallback clauses just stop firing.

## BREAKING CHANGE
Connection, TLS and version-negotiation failures now return `%Bolty.Error{}` rather than a bare string / raw posix or exception tuple. Callers matching those specific shapes must match `%Bolty.Error{}`. (`{:error, _}` matchers are unaffected.)

## Scope
The `raise ":username is missing"` → clean error stays in #71 (config path).