### PR TITLE
fix: uniform config precedence and remove env-var config

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,8 +275,8 @@ As certain versions of Bolt may be compatible with specific functionalities whil
 
 By default, all tags are disabled except the `:core` tag. To enable the tags, it is necessary to configure the following environment variables:
 
-- `BOLT_VERSIONS`: **Deprecated** — use the `:versions` connection option instead. Still supported as a testing escape hatch (e.g. `BOLT_VERSIONS=5.4 mix test`), but will emit a warning at runtime.
-- `BOLT_TCP_PORT`:  You can configure the port with the environment variable (BOLT_TCP_PORT=7688).
+- `BOLT_VERSIONS`: selects the Bolt version the **test suite** negotiates and which version tags run (e.g. `BOLT_VERSIONS=5.4 mix test`). This is a test-suite convenience only — configure the driver itself with the `:versions` connection option.
+- `BOLT_TCP_PORT`: the port the **test suite** connects to (default 7687). Configure the driver itself with the `:port` connection option.
 
 #### Version matrix
 To run the suite against every supported Bolt version, use `mix test.matrix` (see `mix help test.matrix`). It reads `BOLT_TCP_PORT` for Bolt 5.x servers and `BOLT_6_TCP_PORT` for Bolt 6.x.

--- a/lib/bolty.ex
+++ b/lib/bolty.ex
@@ -11,9 +11,9 @@ defmodule Bolty do
   @typedoc """
   The basic authentication scheme relies on traditional username and password
 
-  * `:username` - Username (default: `BOLT_USER` env variable)
+  * `:username` - Username (required)
 
-  * `:password` - Password (default: `BOLT_PWD` env variable, then `nil`)
+  * `:password` - Password (default: `nil`)
   """
   @type basic_auth() ::
           {:username, String.t()}
@@ -47,12 +47,13 @@ defmodule Bolty do
 
   ## Options
 
-  * `:uri` - Connection URI. The uri configuration takes priority over the hostname, port, and scheme options.
-   URI has the form: `<SCHEME>://<HOST>[:<PORT>[?policy=<POLICY-NAME>]]`
+  * `:uri` - Connection URI, of the form `<SCHEME>://<HOST>[:<PORT>[?policy=<POLICY-NAME>]]`.
+   Explicit `:hostname`, `:port` and `:scheme` options take priority over the
+   corresponding URI components.
 
-  * `:hostname` - Server hostname (default: `BOLT_HOST` env variable, then `"localhost"`)
+  * `:hostname` - Server hostname (default: `"localhost"`)
 
-  * `:port` - Server port (default: `BOLT_TCP_PORT` env variable, then `7687`)
+  * `:port` - Server port (default: `7687`)
 
   * `:scheme` - Is one among neo4j, neo4j+s, neo4j+ssc, bolt, bolt+s, bolt+ssc (default: bolt+s).
 

--- a/lib/bolty/client.ex
+++ b/lib/bolty/client.ex
@@ -10,7 +10,6 @@ defmodule Bolty.Client do
   import Bolty.BoltProtocol.ServerResponse
 
   alias Bolty.BoltProtocol.Versions
-  alias Bolty.Utils.Converters
   alias Bolty.BoltProtocol.MessageDecoder
 
   alias Bolty.BoltProtocol.Message.{
@@ -33,7 +32,11 @@ defmodule Bolty.Client do
     @moduledoc false
 
     @default_timeout 15_000
+    @default_port 7687
 
+    # Redact the password so a failed-connect crash report (DBConnection includes
+    # state/opts) can't leak it to logs.
+    @derive {Inspect, except: [:password]}
     defstruct [
       :hostname,
       :port,
@@ -48,26 +51,45 @@ defmodule Bolty.Client do
       :ssl_opts
     ]
 
+    @doc """
+    Builds a `%Config{}` from connection options.
+
+    Returns `{:ok, config}`, or `{:error, %Bolty.Error{}}` when a required field
+    (currently `:username`) is missing — the caller surfaces that cleanly rather
+    than raising inside DBConnection's connect callback.
+    """
     def new(opts) do
       {hostname, port} = get_hostname_and_port(opts)
       {username, password} = get_user_and_pass(opts)
       {scheme, ssl?, tls_verify, ssl_opts} = get_scheme_and_ssl_opts(opts)
       versions = get_versions(opts)
 
-      %__MODULE__{
-        hostname: hostname,
-        port: port,
-        scheme: scheme,
-        username: username,
-        password: password,
-        connect_timeout: Keyword.get(opts, :connect_timeout, @default_timeout),
-        socket_options:
-          Keyword.merge([mode: :binary, packet: :raw, active: false], opts[:socket_options] || []),
-        versions: versions,
-        ssl?: ssl?,
-        tls_verify: tls_verify,
-        ssl_opts: ssl_opts
-      }
+      if is_nil(username) do
+        {:error,
+         Bolty.Error.wrap(Bolty.Client, %{
+           code: :missing_username,
+           message: ":username is missing — set auth: [username: ...] in your connection config"
+         })}
+      else
+        {:ok,
+         %__MODULE__{
+           hostname: hostname,
+           port: port,
+           scheme: scheme,
+           username: username,
+           password: password,
+           connect_timeout: Keyword.get(opts, :connect_timeout, @default_timeout),
+           socket_options:
+             Keyword.merge(
+               [mode: :binary, packet: :raw, active: false],
+               opts[:socket_options] || []
+             ),
+           versions: versions,
+           ssl?: ssl?,
+           tls_verify: tls_verify,
+           ssl_opts: ssl_opts
+         }}
+      end
     end
 
     # Maps the connection scheme to a TLS *intent*, not materialised ssl options:
@@ -102,69 +124,28 @@ defmodule Bolty.Client do
 
     defp get_user_and_pass(opts) do
       basic_auth = Keyword.get(opts, :auth, [])
-
-      username =
-        System.get_env("BOLT_USER") || Keyword.get(basic_auth, :username, nil) ||
-          raise(":username is missing")
-
-      password = System.get_env("BOLT_PWD") || Keyword.get(basic_auth, :password)
-
-      {username, password}
+      {Keyword.get(basic_auth, :username), Keyword.get(basic_auth, :password)}
     end
 
+    # Precedence, uniform across host/port/scheme: explicit opts > URI components
+    # > default. (No env vars — those were removed in 0.3.0.)
     defp get_hostname_and_port(opts) do
-      uri = Keyword.get(opts, :uri, nil)
-
-      parsed_uri =
-        uri
-        |> to_string
-        |> URI.parse()
-
-      port_default = String.to_integer(System.get_env("BOLT_TCP_PORT") || "7687")
-
-      hostname =
-        parsed_uri.host || Keyword.get(opts, :hostname, nil) || System.get_env("BOLT_HOST") ||
-          "localhost"
-
-      port = parsed_uri.port || Keyword.get(opts, :port, port_default)
+      parsed_uri = parse_uri(opts)
+      hostname = Keyword.get(opts, :hostname) || parsed_uri.host || "localhost"
+      port = Keyword.get(opts, :port) || parsed_uri.port || @default_port
       {hostname, port}
     end
 
     defp get_schema(opts) do
-      uri = Keyword.get(opts, :uri, nil)
+      Keyword.get(opts, :scheme) || parse_uri(opts).scheme || "bolt+s"
+    end
 
-      parsed_uri =
-        uri
-        |> to_string
-        |> URI.parse()
-
-      parsed_uri.scheme || Keyword.get(opts, :scheme, nil) || "bolt+s"
+    defp parse_uri(opts) do
+      opts |> Keyword.get(:uri) |> to_string() |> URI.parse()
     end
 
     def get_versions(opts) do
-      versions =
-        case Keyword.get(opts, :versions) do
-          nil ->
-            case System.get_env("BOLT_VERSIONS") do
-              nil ->
-                Versions.latest_versions()
-
-              env_versions ->
-                require Logger
-
-                Logger.warning(
-                  "BOLT_VERSIONS env var is deprecated — set :versions in your connection config instead"
-                )
-
-                env_versions
-                |> String.split(",")
-                |> Enum.map(&Converters.to_float/1)
-            end
-
-          ops_versions ->
-            ops_versions
-        end
-
+      versions = Keyword.get(opts, :versions) || Versions.latest_versions()
       ((versions |> Enum.into([])) ++ [0, 0, 0]) |> Enum.take(4) |> Enum.sort(&>=/2)
     end
   end
@@ -176,7 +157,9 @@ defmodule Bolty.Client do
   end
 
   def connect(opts) when is_list(opts) do
-    connect(Config.new(opts))
+    with {:ok, config} <- Config.new(opts) do
+      connect(config)
+    end
   end
 
   def do_connect(config) do

--- a/lib/bolty/connection.ex
+++ b/lib/bolty/connection.ex
@@ -22,9 +22,8 @@ defmodule Bolty.Connection do
 
   @impl true
   def connect(opts) do
-    config = Client.Config.new(opts)
-
-    with {:ok, %Client{} = client} <- Client.connect(config) do
+    with {:ok, config} <- Client.Config.new(opts),
+         {:ok, %Client{} = client} <- Client.connect(config) do
       # Resolve a preliminary policy from bolt_version alone so that HELLO
       # message construction can use policy fields (e.g. notifications_field)
       # rather than reading bolt_version directly. The final policy is resolved

--- a/test/bolty/client_test.exs
+++ b/test/bolty/client_test.exs
@@ -39,7 +39,7 @@ defmodule Bolty.ClientTest do
         auth: [username: "usertest"]
       ]
 
-      config = Client.Config.new(opts)
+      assert {:ok, config} = Client.Config.new(opts)
 
       assert config.hostname == "hobby-happyHoHoHo.dbs.graphenedb.com"
       assert config.scheme == "bolt"
@@ -52,9 +52,10 @@ defmodule Bolty.ClientTest do
         auth: [username: "usertest"]
       ]
 
-      config = Client.Config.new(opts)
+      assert {:ok, config} = Client.Config.new(opts)
 
       assert config.hostname == "localhost"
+      assert config.port == 7687
       assert config.scheme == "bolt+s"
       assert config.username == "usertest"
     end
@@ -67,7 +68,7 @@ defmodule Bolty.ClientTest do
         auth: [username: "usertests"]
       ]
 
-      config = Client.Config.new(opts)
+      assert {:ok, config} = Client.Config.new(opts)
 
       assert config.hostname == "hobby-happyHoHoHo.dbs.com"
       assert config.scheme == "bolt+s"
@@ -75,21 +76,32 @@ defmodule Bolty.ClientTest do
       assert config.username == "usertests"
     end
 
-    test "passing port, scheme and host along with uri" do
+    test "explicit :hostname/:port/:scheme opts take priority over URI components" do
       opts = [
         uri: "bolt://hobby-happyHoHoHo.dbs.graphenedb.com:24786",
         hostname: "happy.com",
-        scheme: "bolts",
+        scheme: "neo4j",
         port: 7689,
         auth: [username: "usertests"]
       ]
 
-      config = Client.Config.new(opts)
+      assert {:ok, config} = Client.Config.new(opts)
 
-      assert config.hostname == "hobby-happyHoHoHo.dbs.graphenedb.com"
-      assert config.scheme == "bolt"
-      assert config.port == 24786
+      # 0.3.0: explicit opts win over URI (the previous behaviour was the reverse).
+      assert config.hostname == "happy.com"
+      assert config.scheme == "neo4j"
+      assert config.port == 7689
       assert config.username == "usertests"
+    end
+
+    test "missing :username returns a %Bolty.Error{}, does not raise" do
+      assert {:error, %Bolty.Error{module: Bolty.Client, code: :missing_username}} =
+               Client.Config.new(hostname: "localhost")
+    end
+
+    test "the password is redacted when the config is inspected" do
+      {:ok, config} = Client.Config.new(auth: [username: "u", password: "s3cret"])
+      refute inspect(config) =~ "s3cret"
     end
 
     test "maps schemes to the correct TLS verification intent" do
@@ -99,34 +111,34 @@ defmodule Bolty.ClientTest do
 
       opts1 = base_opts ++ [scheme: "bolt"]
 
-      assert %Client.Config{scheme: "bolt", ssl?: false, tls_verify: :none} =
+      assert {:ok, %Client.Config{scheme: "bolt", ssl?: false, tls_verify: :none}} =
                Client.Config.new(opts1)
 
       # +s -> full verification (previously, and incorrectly, :verify_none)
       opts2 = base_opts ++ [scheme: "bolt+s"]
 
-      assert %Client.Config{scheme: "bolt+s", ssl?: true, tls_verify: :verify} =
+      assert {:ok, %Client.Config{scheme: "bolt+s", ssl?: true, tls_verify: :verify}} =
                Client.Config.new(opts2)
 
       # +ssc -> self-signed / trust-all (previously, and incorrectly, :verify_peer)
       opts3 = base_opts ++ [scheme: "bolt+ssc"]
 
-      assert %Client.Config{scheme: "bolt+ssc", ssl?: true, tls_verify: :self_signed} =
+      assert {:ok, %Client.Config{scheme: "bolt+ssc", ssl?: true, tls_verify: :self_signed}} =
                Client.Config.new(opts3)
 
       opts4 = base_opts ++ [scheme: "neo4j"]
 
-      assert %Client.Config{scheme: "neo4j", ssl?: false, tls_verify: :none} =
+      assert {:ok, %Client.Config{scheme: "neo4j", ssl?: false, tls_verify: :none}} =
                Client.Config.new(opts4)
 
       opts5 = base_opts ++ [scheme: "neo4j+s"]
 
-      assert %Client.Config{scheme: "neo4j+s", ssl?: true, tls_verify: :verify} =
+      assert {:ok, %Client.Config{scheme: "neo4j+s", ssl?: true, tls_verify: :verify}} =
                Client.Config.new(opts5)
 
       opts6 = base_opts ++ [scheme: "neo4j+ssc"]
 
-      assert %Client.Config{scheme: "neo4j+ssc", ssl?: true, tls_verify: :self_signed} =
+      assert {:ok, %Client.Config{scheme: "neo4j+ssc", ssl?: true, tls_verify: :self_signed}} =
                Client.Config.new(opts6)
     end
 
@@ -139,10 +151,11 @@ defmodule Bolty.ClientTest do
 
       # The strict defaults are materialised at connect time; Config keeps the
       # user's opts raw so they can be merged *over* the defaults (user wins).
-      assert %Client.Config{
-               tls_verify: :verify,
-               ssl_opts: [verify: :verify_peer, cacertfile: "/etc/ssl/my_ca.pem"]
-             } = Client.Config.new(opts)
+      assert {:ok,
+              %Client.Config{
+                tls_verify: :verify,
+                ssl_opts: [verify: :verify_peer, cacertfile: "/etc/ssl/my_ca.pem"]
+              }} = Client.Config.new(opts)
     end
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -63,6 +63,7 @@ defmodule Bolty.TestHelper do
       scheme: "bolt",
       ssl: false
     ]
+    |> with_env_overrides()
   end
 
   def opts_without_auth() do
@@ -76,6 +77,31 @@ defmodule Bolty.TestHelper do
       scheme: "bolt",
       ssl: false
     ]
+    |> with_env_overrides()
+  end
+
+  # The driver no longer reads BOLT_VERSIONS / BOLT_TCP_PORT (removed in 0.3.0);
+  # the test matrix (mix test.matrix / CI) still uses them to pick the Bolt
+  # version and server port, so bridge them into explicit :versions / :port opts.
+  defp with_env_overrides(opts) do
+    opts
+    |> maybe_put_env_port()
+    |> maybe_put_env_versions()
+  end
+
+  defp maybe_put_env_port(opts) do
+    case System.get_env("BOLT_TCP_PORT") do
+      nil -> opts
+      "" -> opts
+      port -> Keyword.put(opts, :port, String.to_integer(port))
+    end
+  end
+
+  defp maybe_put_env_versions(opts) do
+    case System.get_env("BOLT_VERSIONS", "") |> String.split(",") |> Enum.reject(&(&1 == "")) do
+      [] -> opts
+      versions -> Keyword.put(opts, :versions, Enum.map(versions, &Converters.to_float/1))
+    end
   end
 
   defp ssl_opts() do

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -85,12 +85,12 @@ Canonical option names (what `Bolty.Client.Config.new/1` actually reads):
 
 | Option | Meaning | Default |
 | --- | --- | --- |
-| `:uri` | `<scheme>://<host>[:<port>]` — wins over host/port/scheme | `nil` |
-| `:hostname` | Host | `BOLT_HOST` env → `"localhost"` |
-| `:port` | Port | `BOLT_TCP_PORT` env → `7687` |
+| `:uri` | `<scheme>://<host>[:<port>]` — explicit `:hostname`/`:port`/`:scheme` win over the URI's components | `nil` |
+| `:hostname` | Host | `"localhost"` |
+| `:port` | Port | `7687` |
 | `:scheme` | One of the schemes below | `"bolt+s"` |
-| `:auth` | `[username: ..., password: ...]` | required |
-| `:versions` | Bolt versions to negotiate. Accepts floats (`[5.4]`) or range tuples (`[{5, 6..8}, {5, 0..4}]`). Range tuples are preferred — the handshake has only 4 slots and ranges cover more versions per slot. Omit to use `Versions.latest_versions()` (all supported versions, auto-rangeified). `BOLT_VERSIONS` env var is **deprecated** in favour of this option. | `Versions.latest_versions()` |
+| `:auth` | `[username: ..., password: ...]` (`:username` required) | required |
+| `:versions` | Bolt versions to negotiate. Accepts floats (`[5.4]`) or range tuples (`[{5, 6..8}, {5, 0..4}]`). Range tuples are preferred — the handshake has only 4 slots and ranges cover more versions per slot. Omit to use `Versions.latest_versions()` (all supported versions, auto-rangeified). | `Versions.latest_versions()` |
 | `:user_agent` | Client identity string | `"bolty/<version>"` |
 | `:notifications_minimum_severity` | Bolt 5.2+ | `nil` |
 | `:notifications_disabled_categories` | Bolt 5.2–5.5 | `nil` |
@@ -100,7 +100,7 @@ Canonical option names (what `Bolty.Client.Config.new/1` actually reads):
 | `:socket_options` | `:gen_tcp.connect_option()` list | `[mode: :binary, packet: :raw, active: false]` |
 | DBConnection opts (`:name`, `:pool_size`, `:max_overflow`, `:after_connect`, ...) | flow through | |
 
-**Env-var precedence for auth is a sharp edge**: `BOLT_USER` and `BOLT_PWD` override the values you pass in `:auth`. Unset them explicitly if you don't want that.
+**Precedence is uniform**: explicit opts (`:hostname`/`:port`/`:scheme`) win over the corresponding `:uri` components. The driver reads no environment variables for connection config (the old `BOLT_USER`/`BOLT_PWD`/`BOLT_HOST`/`BOLT_TCP_PORT`/`BOLT_VERSIONS` were removed in 0.3.0 — pass `:auth`, `:hostname`, `:port`, `:versions` instead).
 
 ### URI schemes / TLS
 
@@ -198,7 +198,7 @@ If an agent needs routing or streaming today, that is not bolty's job — surfac
 
 Tests are version-tagged. Defaults run only `:core`; everything else is disabled unless you opt in with env vars and tags.
 
-- Env vars: `BOLT_VERSIONS` (e.g. `"5.2"`), `BOLT_TCP_PORT` (e.g. `7687`), `BOLT_USER`, `BOLT_PWD`, `BOLT_HOST`.
+- Env vars (test suite only — the driver reads none of these): `BOLT_VERSIONS` (e.g. `"5.2"`) selects the negotiated version and version tags; `BOLT_TCP_PORT` (e.g. `7687`) sets the server port. The test helper bridges them into the `:versions` / `:port` connection options.
 - Tags: `:core`, `:bolt_version_X_Y` (e.g. `:bolt_version_5_2`), `:bolt_X_x` (e.g. `:bolt_5_x`), `:last_version`.
 
 Local server matrix via `docker-compose.yml`:
@@ -276,7 +276,7 @@ To add a dimension: add the field to `Bolty.Policy`, extend `Bolty.Policy.Resolv
 
 - `@error_map` only covers four Neo bolt errors; everything else collapses to `:unknown`. Extend when you need finer-grained handling.
 - `format_param/1` at the top level only rewrites `Point`. Temporal-with-offset structs pass through as-is; call their own `format_param/1` if you need Cypher-ready strings.
-- Env-var-overrides-opts precedence for `:auth` (BOLT_USER / BOLT_PWD) — as noted in §5.
+- A missing `:username` returns `{:error, %Bolty.Error{code: :missing_username}}` from the connect path (it no longer raises). (The old `BOLT_USER`/`BOLT_PWD`/`BOLT_HOST`/`BOLT_TCP_PORT`/`BOLT_VERSIONS` env-var config was removed in 0.3.0 — pass explicit options.)
 
 ## 16. Commit format and changelog
 


### PR DESCRIPTION
Fixes #71 (the final P0 in the 0.3.0 breaking batch).

## Problem
Config resolution was inconsistent and preferred ambient env state: user/password had **env beating explicit opts** (a stray `BOLT_USER` could connect as the wrong user), while host/port/scheme were `URI > opt > env`. A missing `:username` also **raised** inside `connect/1`, crash-looping DBConnection.

## Fix
- **Uniform precedence** across host/port/scheme: **explicit opts > URI components > default** (flips the previous `URI > opt` ordering).
- **Remove all env-var connection config** — `BOLT_USER`, `BOLT_PWD`, `BOLT_HOST`, `BOLT_TCP_PORT`, `BOLT_VERSIONS`; pass `:auth`, `:hostname`, `:port`, `:versions`.
- `Config.new/1` now returns `{:ok, config} | {:error, %Bolty.Error{}}`; a missing `:username` yields `%Bolty.Error{code: :missing_username}` **instead of raising**. `Client.connect/1` and `Connection.connect/1` thread the result.
- `@derive {Inspect, except: [:password]}` on `Config` so a failed-connect crash report can't leak the password.

## Test harness
`mix test.matrix`/CI still parametrise via `BOLT_VERSIONS`/`BOLT_TCP_PORT`, now **bridged into `:versions`/`:port` opts by `TestHelper`** (the driver no longer reads them). Verified the matrix still routes correctly and the full-negotiation path (no `BOLT_VERSIONS`) works.

## Tests / docs
- New tests: explicit-opts-win-over-URI, missing-username → `%Bolty.Error{}`, password redaction on inspect, refused-connection wrapping (from #70).
- Existing config tests updated to the `{:ok, config}` contract.
- README + usage-rules.md updated (env vars reframed as test-suite-only / removed; precedence corrected).
- 282 plaintext + 4 TLS tests pass; dialyzer clean; format clean.

## Consumer safety
`ash_neo4j` configures via explicit opts / `Application.get_env`, not env vars — no impact. No struct-shape coupling.

## BREAKING CHANGE
`BOLT_*` env-var config is no longer read — pass explicit options. Explicit `:hostname`/`:port`/`:scheme` now win over `:uri` components (previously reversed). A missing `:username` returns `{:error, %Bolty.Error{}}` rather than raising.