### PR TITLE
fix: raise Elixir floor to ~> 1.17 and CI-test it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,24 @@ jobs:
         run: mix compile --force --warnings-as-errors
       - name: Dialyzer
         run: mix dialyzer --format github
+
+  floor:
+    # Exercise the advertised Elixir floor (mix.exs `elixir: "~> 1.17"`) so the
+    # package can't claim a version it won't compile on — e.g. Duration is 1.17+.
+    name: Compile on the Elixir floor (1.17)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: '27.2'
+          elixir-version: '1.17.3'
+
+      - run: mix deps.get
+      - name: Compile on the floor
+        run: mix compile
   test:
     name: BoltVersion ${{ matrix.boltVersion }}, DB ${{matrix.db}}
     runs-on: ubuntu-latest

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule Bolty.Mixfile do
     [
       app: :bolty,
       version: @version,
-      elixir: "~> 1.14",
+      elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps(),
       package: package(),

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -214,7 +214,7 @@ Use `mix test.matrix` to run the full version matrix. Requires Docker and docker
 
 ## 13. Development loop
 
-- Elixir `~> 1.14`. `.tool-versions` pins the expected runtime.
+- Elixir `~> 1.17` (the `Duration` type is 1.17+). `.tool-versions` pins the expected runtime.
 - `mix format` — `.formatter.exs` configured.
 - `mix credo` — `.credo.exs` tuned; keep warnings at 0.
 - `mix dialyzer` — PLT adds `:jason`, `:poison`, `:mix`; `.dialyzer_ignore.exs` holds accepted noise.


### PR DESCRIPTION
Fixes #72 (the final P0 in the 0.3.0 batch).

## Problem
`mix.exs` declared `elixir: "~> 1.14"`, but `packer.ex` and `types_helper.ex` use `Duration` (introduced in Elixir 1.17) — so the package couldn't compile on its own advertised 1.14–1.16 range. Hex would let a 1.14 user fetch a package that won't build.

## Fix
- Set `elixir: "~> 1.17"`.
- Add a CI **floor** job that compiles on **Elixir 1.17.3 / OTP 27.2**, so the advertised minimum is actually exercised on every PR (the other jobs only run 1.20.2/OTP 29).
- Update the usage-rules Elixir requirement.

## Notes
`~> 1.17` confirmed as the binding floor (no JSON/other newer stdlib usage). `MIX_ENV=prod` was considered for the floor job but bolty has no `config/prod.exs` (its config is dev/test only, not shipped), so the job uses the default env — still a faithful "does it compile on 1.17" check.