### PR TITLE
docs: address quick docs package wins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Typical flow:
 3. `mix git_ops.release` on `dev` — bumps `@version` in `mix.exs`, updates the README dep snippet, writes the `CHANGELOG.md` section, commits and tags `vX.Y.Z`. `feat` → minor, `fix`/etc. → patch (pre-1.0 too).
 4. Push `dev` and the tag; merge `dev` → `main`; `gh release create vX.Y.Z`; then **you** run `mix hex.publish` (needs Hex credentials).
 
-Docs-only fix right after publishing? Within Hex's ~1-hour window you can correct the README, **move the tag** onto the fix, and re-publish the same version (`git tag -f`, `git push -f` the tag). Only `README.md` + `CHANGELOG.md` ship in the package (`mix.exs` `files`), so a fix to `usage-rules.md` / this file does not need a republish.
+Docs-only fix right after publishing? Within Hex's ~1-hour window you can correct the README, **move the tag** onto the fix, and re-publish the same version (`git tag -f`, `git push -f` the tag). `README.md`, `CHANGELOG.md`, and `usage-rules.md` ship in the package (`mix.exs` `files`), so a fix to those docs may need a republish.
 
 ## CI
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Documentation: [https://hexdocs.pm/bolty](https://hexdocs.pm/bolty)
 
 | Feature               | Implemented |
 | --------------------- | ------------ |
-| Querys                | YES          |
+| Queries               | YES          |
 | Transactions          | YES          |
 | Stream capabilities   | NO           |
 | Routing               | NO           |
@@ -66,9 +66,9 @@ iex> {:ok, conn} = Bolty.start_link(opts)
 iex> Bolty.query!(conn, "return 1 as n") |> Bolty.Response.first()
 %{"n" => 1}
 
-# Commit is performed automatically if everythings went fine
+# Commit is performed automatically if everything went fine
 Bolty.transaction(conn, fn conn ->
-  result = Bolty.query!(conn, "CREATE (m:Movie {title: "Matrix"}) RETURN m")
+  result = Bolty.query!(conn, "CREATE (m:Movie {title: 'Matrix'}) RETURN m")
 end)
 
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -84,6 +84,7 @@ defmodule Bolty.Mixfile do
         "mix.exs",
         "README.md",
         "CHANGELOG.md",
+        "usage-rules.md",
         "LICENSE",
         "NOTICE",
         "LICENSES",
@@ -103,6 +104,7 @@ defmodule Bolty.Mixfile do
   defp docs() do
     [
       source_ref: "v#{@version}",
+      source_url: @url_github,
       main: "readme",
       extras: ["README.md", "CHANGELOG.md"]
     ]


### PR DESCRIPTION
Addresses part of #80.

## Summary
- fix the README feature table typo from `Querys` to `Queries`
- fix the README transaction example so the Cypher string no longer breaks Elixir string quoting, plus the adjacent `everythings` typo
- add `source_url` to ExDoc config
- include `usage-rules.md` in the Hex package files list and update the contributor note that describes shipped docs

## Validation
- `git diff --check`
- reviewed the changed README and `mix.exs` hunks locally

## Notes
- I did not run `mix format`/`mix test` because Elixir/Mix is not installed in this Windows environment.
- I left the dependency cleanup checklist item alone because removing deps should update/verify the Mix lockfile with the Elixir toolchain available.