### PR TITLE
feat: emit :telemetry events for query and connect lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,15 @@ Supported element types:
 - `:float32` — IEEE-754 single precision (4 bytes per element)
 - `:float64` — IEEE-754 double precision (8 bytes per element)
 
+## Telemetry
+
+Bolty emits [`:telemetry`](https://hexdocs.pm/telemetry) events for the query
+(`[:bolty, :query, :start | :stop | :exception]`) and connection
+(`[:bolty, :connect | :disconnect]`) lifecycle, so you can attach query latency,
+pool health, and error-rate metrics without wrapping every call site. See the
+[Telemetry guide](guides/telemetry.md) for the full event/measurement/metadata
+reference.
+
 ## Contributing
 
 ### Getting Started

--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -1,0 +1,85 @@
+<!--
+SPDX-FileCopyrightText: 2024 bolty contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Telemetry
+
+Bolty emits [`:telemetry`](https://hexdocs.pm/telemetry) events for the query and
+connection lifecycle, so you can wire query latency, pool health, and error rates
+into your own metrics/tracing without wrapping every call site.
+
+Attach a handler at application start:
+
+```elixir
+:telemetry.attach_many(
+  "bolty-logger",
+  [
+    [:bolty, :query, :stop],
+    [:bolty, :query, :exception],
+    [:bolty, :connect],
+    [:bolty, :disconnect]
+  ],
+  &MyApp.Telemetry.handle_event/4,
+  nil
+)
+```
+
+Durations are in `:native` time units — convert with
+`System.convert_time_unit(duration, :native, :millisecond)`.
+
+## Query events
+
+`Bolty.query/4`, `Bolty.query!/4`, `Bolty.query_many/4`, and `Bolty.query_many!/4`
+wrap the server round-trip in a [`:telemetry.span/3`](https://hexdocs.pm/telemetry/telemetry.html#span/3),
+emitting the standard start/stop/exception trio under `[:bolty, :query]`.
+
+| Event | Measurements | Metadata |
+| --- | --- | --- |
+| `[:bolty, :query, :start]` | `:monotonic_time`, `:system_time` | `:db_system`, `:db_statement`, `:db_instance`, `:telemetry_span_context` |
+| `[:bolty, :query, :stop]` | `:monotonic_time`, `:duration` | `:db_system`, `:db_statement`, `:db_instance`, `:result`, (`:error`), `:telemetry_span_context` |
+| `[:bolty, :query, :exception]` | `:monotonic_time`, `:duration` | `:db_system`, `:db_statement`, `:db_instance`, `:kind`, `:reason`, `:stacktrace`, `:telemetry_span_context` |
+
+Metadata keys:
+
+- `:db_system` — always `"neo4j"`.
+- `:db_statement` — the Cypher statement string.
+- `:db_instance` — the target database from the `:db` option, or `nil` for the
+  server default.
+- `:result` — `:ok` or `:error`, a coarse outcome status you can map straight onto
+  a span status. A server-side failure (e.g. a Cypher error) is an `:error`
+  **`:stop`**, not an `:exception`; the `:exception` event fires only when a call
+  raises (e.g. a `DBConnection.ConnectionError` on a checkout/queue timeout).
+- `:error` — present only when `:result` is `:error`: the `%Bolty.Error{}` (or a
+  `%DBConnection.ConnectionError{}`) returned to the caller.
+
+Query **parameters are not included** in metadata — they routinely carry secrets.
+
+## Connection events
+
+| Event | Measurements | Metadata |
+| --- | --- | --- |
+| `[:bolty, :connect]` | `:duration` | `:db_system`, `:bolt_version`, `:server_version`, `:connection_id` |
+| `[:bolty, :disconnect]` | `:system_time` | `:db_system`, `:connection_id` |
+
+## Mapping to OpenTelemetry
+
+The `:db_*` metadata keys mirror the OpenTelemetry
+[database semantic conventions](https://opentelemetry.io/docs/specs/semconv/database/)
+(dots become underscores, since `:telemetry` metadata keys are atoms), so a bridge
+such as [`opentelemetry_telemetry`](https://hex.pm/packages/opentelemetry_telemetry)
+can translate an event into a span with minimal glue:
+
+| Bolty metadata | OpenTelemetry attribute |
+| --- | --- |
+| `:db_system` | `db.system` (`"neo4j"`) |
+| `:db_statement` | `db.statement` |
+| `:db_instance` | `db.instance` |
+
+These follow the classic `db.*` names; recent semconv revisions rename some
+(`db.statement` → `db.query.text`, `db.instance` → `db.namespace`) — map them in
+your handler if you target the newer spec.
+
+`[:bolty, :connect]` fires once a connection is fully established (HELLO/LOGON
+complete); `:duration` covers config parsing, the TCP/TLS connect, and the Bolt
+handshake. `[:bolty, :disconnect]` fires when DBConnection tears a connection down.

--- a/lib/bolty.ex
+++ b/lib/bolty.ex
@@ -207,12 +207,41 @@ defmodule Bolty do
     info
   end
 
+  # Wrap the round-trip in a `[:bolty, :query]` telemetry span so operators get
+  # `:start`/`:stop`/`:exception` events with duration, statement, and outcome
+  # without instrumenting every call site. See `guides/telemetry.md`.
+  #
+  # This span is for the EAGER path only: `:telemetry.span` closes when the fun
+  # returns, and here that means the full result is materialised. Lazy streaming
+  # (#59, via handle_declare/handle_fetch) must NOT reuse this — a cursor returns
+  # before any rows are pulled, so the span would time only RUN and would stuff
+  # the whole materialised result into `:result`. Streaming needs its own
+  # start-on-declare / stop-on-deallocate instrumentation carrying row counts.
   defp do_query(conn, query, params, options) do
-    case DBConnection.prepare_execute(conn, query, params, options) do
-      {:ok, _query, result} -> {:ok, result}
-      {:error, _} = error -> error
-    end
+    metadata = %{
+      db_system: "neo4j",
+      db_statement: statement(query),
+      db_instance: options[:db]
+    }
+
+    # `:telemetry.span` fires `:exception` (and reraises) if the fun raises/exits;
+    # for the `{:error, _}` return we flag a coarse `:result` status and stash the
+    # error so tracers can set span status without us holding the whole result.
+    :telemetry.span([:bolty, :query], metadata, fn ->
+      case DBConnection.prepare_execute(conn, query, params, options) do
+        {:ok, _query, result} ->
+          {{:ok, result}, Map.put(metadata, :result, :ok)}
+
+        # prepare_execute always surfaces failures as an exception struct
+        # (%Bolty.Error{} or %DBConnection.ConnectionError{}).
+        {:error, error} = failure ->
+          {failure, metadata |> Map.put(:result, :error) |> Map.put(:error, error)}
+      end
+    end)
   end
+
+  defp statement(%Bolty.Query{statement: statement}), do: statement
+  defp statement(%Bolty.Queries{statement: statement}), do: statement
 
   defp format_param({name, value}), do: {name, {:ok, value}}
 end

--- a/lib/bolty/connection.ex
+++ b/lib/bolty/connection.ex
@@ -22,6 +22,8 @@ defmodule Bolty.Connection do
 
   @impl true
   def connect(opts) do
+    start = System.monotonic_time()
+
     with {:ok, config} <- Client.Config.new(opts),
          {:ok, %Client{} = client} <- Client.connect(config) do
       # Resolve a preliminary policy from bolt_version alone so that HELLO
@@ -36,7 +38,20 @@ defmodule Bolty.Connection do
       with {:ok, response_server_metadata} <- do_init(client_with_policy, opts) do
         policy = Policy.Resolver.resolve(client.bolt_version, response_server_metadata)
         state = get_server_metadata_state(response_server_metadata)
-        {:ok, %__MODULE__{state | client: %{client | policy: policy}, policy: policy}}
+        new_state = %__MODULE__{state | client: %{client | policy: policy}, policy: policy}
+
+        :telemetry.execute(
+          [:bolty, :connect],
+          %{duration: System.monotonic_time() - start},
+          %{
+            db_system: "neo4j",
+            bolt_version: client.bolt_version,
+            server_version: new_state.server_version,
+            connection_id: new_state.connection_id
+          }
+        )
+
+        {:ok, new_state}
       end
     end
   end
@@ -108,6 +123,12 @@ defmodule Bolty.Connection do
 
   @impl true
   def disconnect(_reason, state) do
+    :telemetry.execute(
+      [:bolty, :disconnect],
+      %{system_time: System.system_time()},
+      %{db_system: "neo4j", connection_id: state.connection_id}
+    )
+
     Client.send_goodbye(state.client)
     Client.disconnect(state.client)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -104,7 +104,7 @@ defmodule Bolty.Mixfile do
     [
       source_ref: "v#{@version}",
       main: "readme",
-      extras: ["README.md", "CHANGELOG.md"]
+      extras: ["README.md", "guides/telemetry.md", "CHANGELOG.md"]
     ]
   end
 
@@ -112,6 +112,7 @@ defmodule Bolty.Mixfile do
   defp deps do
     [
       {:db_connection, "~> 2.7"},
+      {:telemetry, "~> 1.0"},
       {:jason, "~> 1.4", optional: true},
       {:poison, "~> 6.0", optional: true},
 

--- a/test/bolty/telemetry_test.exs
+++ b/test/bolty/telemetry_test.exs
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Bolty.TelemetryTest do
+  @moduledoc """
+  Verifies the `[:bolty, :query]` span and the `[:bolty, :connect | :disconnect]`
+  lifecycle events. Needs a live Neo4j (like the rest of the suite).
+  """
+  use ExUnit.Case, async: false
+
+  alias Bolty.Connection
+
+  @opts Bolty.TestHelper.opts()
+
+  # Attach the listed events to a handler that forwards them to the test process,
+  # and detach on exit. Returns the handler id.
+  defp attach(events) do
+    id = "bolty-telemetry-test-#{System.unique_integer([:positive])}"
+    test_pid = self()
+
+    :ok =
+      :telemetry.attach_many(
+        id,
+        events,
+        fn event, measurements, metadata, _config ->
+          send(test_pid, {:telemetry, event, measurements, metadata})
+        end,
+        nil
+      )
+
+    on_exit(fn -> :telemetry.detach(id) end)
+    id
+  end
+
+  describe "query span" do
+    setup do
+      {:ok, conn} = Bolty.start_link([pool_size: 1] ++ @opts)
+      %{conn: conn}
+    end
+
+    @tag :core
+    test "emits start and stop for a successful query", %{conn: conn} do
+      attach([[:bolty, :query, :start], [:bolty, :query, :stop]])
+
+      assert {:ok, _response} = Bolty.query(conn, "RETURN 1 AS n")
+
+      assert_receive {:telemetry, [:bolty, :query, :start], start_meas, start_meta}
+      assert %{system_time: _, monotonic_time: _} = start_meas
+      assert start_meta.db_system == "neo4j"
+      assert start_meta.db_statement == "RETURN 1 AS n"
+
+      assert_receive {:telemetry, [:bolty, :query, :stop], stop_meas, stop_meta}
+      assert is_integer(stop_meas.duration)
+      assert stop_meta.result == :ok
+      refute Map.has_key?(stop_meta, :error)
+    end
+
+    @tag :core
+    test "passes the :db option through as metadata", %{conn: conn} do
+      attach([[:bolty, :query, :stop]])
+
+      Bolty.query(conn, "RETURN 1 AS n", %{}, db: "neo4j")
+
+      assert_receive {:telemetry, [:bolty, :query, :stop], _meas, %{db_instance: "neo4j"}}
+    end
+
+    @tag :core
+    test "a server-side failure is a :stop with an {:error, _} result, not an :exception",
+         %{conn: conn} do
+      attach([[:bolty, :query, :stop], [:bolty, :query, :exception]])
+
+      assert {:error, %Bolty.Error{}} = Bolty.query(conn, "NOT VALID CYPHER")
+
+      assert_receive {:telemetry, [:bolty, :query, :stop], _meas, stop_meta}
+      assert stop_meta.result == :error
+      assert %Bolty.Error{} = stop_meta.error
+      refute_received {:telemetry, [:bolty, :query, :exception], _, _}
+    end
+  end
+
+  describe "connection lifecycle" do
+    @tag :core
+    test "emits connect on establish and disconnect on teardown" do
+      attach([[:bolty, :connect], [:bolty, :disconnect]])
+
+      {:ok, conn_data} = Connection.connect(@opts)
+
+      assert_receive {:telemetry, [:bolty, :connect], connect_meas, connect_meta}
+      assert is_integer(connect_meas.duration)
+      assert is_float(connect_meta.bolt_version)
+      assert is_bitstring(connect_meta.server_version)
+      assert is_bitstring(connect_meta.connection_id)
+
+      :ok = Connection.disconnect(:stop, conn_data)
+
+      assert_receive {:telemetry, [:bolty, :disconnect], _meas, disconnect_meta}
+      assert disconnect_meta.connection_id == connect_meta.connection_id
+    end
+  end
+end


### PR DESCRIPTION
Closes #73.

Zero `:telemetry` usage today — table stakes for a production Bolt driver. This adds the query and connection lifecycle events so operators get query latency, pool health, and error rates without wrapping every call site.

## Events

**Query** — a `:telemetry.span/3` around the eager round-trip in `Bolty.do_query` (covers `query/4`, `query!/4`, `query_many/4`, `query_many!/4`):

| Event | Measurements | Metadata |
| --- | --- | --- |
| `[:bolty, :query, :start]` | `monotonic_time`, `system_time` | `db_system`, `db_statement`, `db_instance` |
| `[:bolty, :query, :stop]` | `monotonic_time`, `duration` | `db_system`, `db_statement`, `db_instance`, `result`, (`error`) |
| `[:bolty, :query, :exception]` | `monotonic_time`, `duration` | `db_system`, `db_statement`, `db_instance`, `kind`, `reason`, `stacktrace` |

**Connection**:

| Event | Measurements | Metadata |
| --- | --- | --- |
| `[:bolty, :connect]` | `duration` | `db_system`, `bolt_version`, `server_version`, `connection_id` |
| `[:bolty, :disconnect]` | `system_time` | `db_system`, `connection_id` |

## Design notes

- **OTel-aligned keys**: metadata mirrors the classic OpenTelemetry `db.*` attributes (`db_system: "neo4j"`, `db_statement`, `db_instance`), so an `opentelemetry_telemetry` bridge is near-trivial. A mapping table is in the guide.
- **Coarse status + error struct**: the `:stop` event carries `result: :ok | :error` (maps straight to a span status) and, on failure, an `:error` key with the `%Bolty.Error{}` / `%DBConnection.ConnectionError{}` struct — rather than stuffing the full materialised result into metadata. A server-side Cypher failure is an `:error` `:stop`, not an `:exception`; `:exception` fires only on a raise (e.g. a checkout/queue timeout).
- **No params in metadata** — they routinely carry secrets.
- **Streaming caveat**: this span is eager-path only. Lazy streaming (#59) must not reuse it — a cursor returns before rows are pulled, so it would time only RUN and stuff the whole result into metadata. Noted as a code comment on `do_query`; #59 will need its own declare→deallocate instrumentation with row counts.

## Docs & deps

- `{:telemetry, "~> 1.0"}` dependency.
- New `guides/telemetry.md` reference page (added to ex_doc extras), with a README pointer.

## Verification

- 4 new tests in `test/bolty/telemetry_test.exs` (query start/stop, `:db` passthrough, server-failure-is-`:stop`-not-`:exception`, connect/disconnect).
- Core query/connection/transaction suites pass.
- `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix dialyzer` (0 errors), `reuse lint` all clean.