### PR TITLE
docs: package and doc-config quick wins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Typical flow:
 3. `mix git_ops.release` on `dev` — bumps `@version` in `mix.exs`, updates the README dep snippet, writes the `CHANGELOG.md` section, commits and tags `vX.Y.Z`. `feat` → minor, `fix`/etc. → patch (pre-1.0 too).
 4. Push `dev` and the tag; merge `dev` → `main`; `gh release create vX.Y.Z`; then **you** run `mix hex.publish` (needs Hex credentials).
 
-Docs-only fix right after publishing? Within Hex's ~1-hour window you can correct the README, **move the tag** onto the fix, and re-publish the same version (`git tag -f`, `git push -f` the tag). Only `README.md` + `CHANGELOG.md` ship in the package (`mix.exs` `files`), so a fix to `usage-rules.md` / this file does not need a republish.
+Docs-only fix right after publishing? Within Hex's ~1-hour window you can correct the README, **move the tag** onto the fix, and re-publish the same version (`git tag -f`, `git push -f` the tag). `README.md`, `CHANGELOG.md`, and `usage-rules.md` ship in the package (`mix.exs` `files`), so a fix to one of those needs a republish to reach Hex; a fix to this file (`AGENTS.md`, not shipped) does not.
 
 ## CI
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Documentation: [https://hexdocs.pm/bolty](https://hexdocs.pm/bolty)
 
 | Feature               | Implemented |
 | --------------------- | ------------ |
-| Querys                | YES          |
+| Queries               | YES          |
 | Transactions          | YES          |
 | Stream capabilities   | NO           |
 | Routing               | NO           |
@@ -66,9 +66,9 @@ iex> {:ok, conn} = Bolty.start_link(opts)
 iex> Bolty.query!(conn, "return 1 as n") |> Bolty.Response.first()
 %{"n" => 1}
 
-# Commit is performed automatically if everythings went fine
+# Commit is performed automatically if everything went fine
 Bolty.transaction(conn, fn conn ->
-  result = Bolty.query!(conn, "CREATE (m:Movie {title: "Matrix"}) RETURN m")
+  result = Bolty.query!(conn, "CREATE (m:Movie {title: 'Matrix'}) RETURN m")
 end)
 
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -84,6 +84,7 @@ defmodule Bolty.Mixfile do
         "mix.exs",
         "README.md",
         "CHANGELOG.md",
+        "usage-rules.md",
         "LICENSE",
         "NOTICE",
         "LICENSES",
@@ -103,6 +104,7 @@ defmodule Bolty.Mixfile do
   defp docs() do
     [
       source_ref: "v#{@version}",
+      source_url: @url_github,
       main: "readme",
       extras: ["README.md", "guides/telemetry.md", "CHANGELOG.md"]
     ]


### PR DESCRIPTION
Part of #80 — the self-contained docs/config quick wins.

## Changes
- **README**: fix the `Querys` → `Queries` feature-table typo; repair the transaction example — the inner double quotes around `"Matrix"` broke the Elixir string literal, so switch to Cypher single quotes (`'Matrix'`) — and the adjacent `everythings` → `everything` typo; add a trailing newline.
- **mix.exs**: add `source_url: @url_github` to the ExDoc config so hexdocs pages link back to the repo.
- **Package**: ship `usage-rules.md` in the Hex package `files` list (verified present via `mix hex.build --unpack`), and update the AGENTS.md release note accordingly — it now ships, so a fix to it needs a republish; `AGENTS.md` itself still does not ship.

## Scope notes
Deferred from this PR, to their parent issues rather than pre-empted here:
- unused-dep removal (`porcelain`/`uuid`) → #79
- `@spec` on `query*` + `Query.extra` fix → #77
- the copy-pasted `unpacker.ex` constant → #76

The `mix credo` CI item is also held back: `mix credo` currently exits non-zero on existing findings, so wiring it in as a hard gate needs a separate decision (fix the findings vs. tune `.credo.exs`). The password `@derive {Inspect, except: [:password]}` item is already done (landed in #71).

## Verification
`mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix docs`, `mix hex.build`, and `reuse lint` all clean.