### PR TITLE
feat: add per-query recv timeouts for post-connect reads

### DIFF
--- a/lib/bolty.ex
+++ b/lib/bolty.ex
@@ -32,6 +32,7 @@ defmodule Bolty do
           | {:ssl, boolean()}
           | {:ssl_opts, [:ssl.tls_client_option()]}
           | {:connect_timeout, timeout()}
+          | {:recv_timeout, timeout()}
           | {:socket_options, [:gen_tcp.connect_option()]}
           | DBConnection.start_option()
 
@@ -74,6 +75,15 @@ defmodule Bolty do
   * `:connect_timeout` - Socket connect timeout in milliseconds (default:
       `15_000`)
 
+  * `:recv_timeout` - Per-read timeout in milliseconds for post-connect protocol
+      reads (default: `15_000`). This is a socket-inactivity timeout: it fires
+      only if the server sends *no* bytes for this long, and the window resets on
+      each chunk received, so streaming a large result is unaffected. A read that
+      times out is surfaced as `{:error, %Bolty.Error{code: :timeout}}` and the
+      connection is disconnected. Can be overridden per query via the same option
+      to `query/4`; set to `:infinity` for queries that may compute for a long
+      time before returning any data.
+
   * `:ssl` - Set to `true` if SSL should be used (default: `true`)
 
   * `:ssl_opts` - A list of SSL options, see `:ssl.connect/2` (default: `[verify: :verify_none]`)
@@ -109,6 +119,14 @@ defmodule Bolty do
   version negotiation, and Neo4j server errors) is surfaced as a `Bolty.Error`,
   so callers can match a single error shape. Pool checkout/timeout failures may
   additionally surface as `DBConnection.ConnectionError`.
+
+  ## Options
+
+  * `:db` - Target database for multi-database routing (default: server default).
+
+  * `:recv_timeout` - Overrides the connection's `:recv_timeout` for this query
+      (see `start_link/1`). Pass `:infinity` for a query expected to run longer
+      than the connection default before returning data.
 
   ## Examples
 

--- a/lib/bolty/client.ex
+++ b/lib/bolty/client.ex
@@ -26,7 +26,7 @@ defmodule Bolty.Client do
     LogoffMessage
   }
 
-  defstruct [:sock, :bolt_version, policy: %Bolty.Policy{}]
+  defstruct [:sock, :bolt_version, :recv_timeout, policy: %Bolty.Policy{}]
 
   defmodule Config do
     @moduledoc false
@@ -44,6 +44,7 @@ defmodule Bolty.Client do
       :username,
       :password,
       :connect_timeout,
+      :recv_timeout,
       :socket_options,
       :versions,
       :ssl?,
@@ -79,6 +80,7 @@ defmodule Bolty.Client do
            username: username,
            password: password,
            connect_timeout: Keyword.get(opts, :connect_timeout, @default_timeout),
+           recv_timeout: Keyword.get(opts, :recv_timeout, @default_timeout),
            socket_options:
              Keyword.merge(
                [mode: :binary, packet: :raw, active: false],
@@ -163,7 +165,7 @@ defmodule Bolty.Client do
   end
 
   def do_connect(config) do
-    client = %__MODULE__{sock: nil, bolt_version: nil}
+    client = %__MODULE__{sock: nil, bolt_version: nil, recv_timeout: config.recv_timeout}
 
     case maybe_connect_to_ssl(client, config) do
       {:ok, client} ->
@@ -334,7 +336,7 @@ defmodule Bolty.Client do
     payload = HelloMessage.encode(client.bolt_version, [{:policy, client.policy} | fields])
 
     with :ok <- send_packet(client, payload) do
-      recv_packets(client, &__MODULE__.prepare_generic_messages/2, :infinity)
+      recv_packets(client, &__MODULE__.prepare_generic_messages/2, client.recv_timeout)
     end
   end
 
@@ -342,7 +344,7 @@ defmodule Bolty.Client do
     payload = LogonMessage.encode(client.bolt_version, fields)
 
     with :ok <- send_packet(client, payload) do
-      recv_packets(client, &__MODULE__.prepare_generic_messages/2, :infinity)
+      recv_packets(client, &__MODULE__.prepare_generic_messages/2, client.recv_timeout)
     end
   end
 
@@ -351,7 +353,7 @@ defmodule Bolty.Client do
       RunMessage.encode(client.bolt_version, query, parameters, extra_parameters, client.policy)
 
     with :ok <- send_packet(client, payload) do
-      recv_packets(client, &RunMessage.prepare_messages/2, :infinity)
+      recv_packets(client, &RunMessage.prepare_messages/2, client.recv_timeout)
     end
   end
 
@@ -359,7 +361,7 @@ defmodule Bolty.Client do
     payload = PullMessage.encode(client.bolt_version, extra_parameters)
 
     with :ok <- send_packet(client, payload) do
-      recv_packets(client, &PullMessage.prepare_messages/2, :infinity)
+      recv_packets(client, &PullMessage.prepare_messages/2, client.recv_timeout)
     end
   end
 
@@ -399,7 +401,7 @@ defmodule Bolty.Client do
     payload = BeginMessage.encode(client.bolt_version, extra_parameters)
 
     with :ok <- send_packet(client, payload) do
-      recv_packets(client, &__MODULE__.prepare_generic_messages/2, :infinity)
+      recv_packets(client, &__MODULE__.prepare_generic_messages/2, client.recv_timeout)
     end
   end
 
@@ -407,7 +409,7 @@ defmodule Bolty.Client do
     payload = CommitMessage.encode(client.bolt_version)
 
     with :ok <- send_packet(client, payload) do
-      recv_packets(client, &__MODULE__.prepare_generic_messages/2, :infinity)
+      recv_packets(client, &__MODULE__.prepare_generic_messages/2, client.recv_timeout)
     end
   end
 
@@ -415,7 +417,7 @@ defmodule Bolty.Client do
     payload = RollbackMessage.encode(client.bolt_version)
 
     with :ok <- send_packet(client, payload) do
-      recv_packets(client, &__MODULE__.prepare_generic_messages/2, :infinity)
+      recv_packets(client, &__MODULE__.prepare_generic_messages/2, client.recv_timeout)
     end
   end
 
@@ -423,7 +425,7 @@ defmodule Bolty.Client do
     payload = ResetMessage.encode(client.bolt_version)
 
     with :ok <- send_packet(client, payload) do
-      recv_packets(client, &__MODULE__.prepare_generic_messages/2, :infinity)
+      recv_packets(client, &__MODULE__.prepare_generic_messages/2, client.recv_timeout)
     end
   end
 
@@ -431,7 +433,7 @@ defmodule Bolty.Client do
     payload = DiscardMessage.encode(client.bolt_version, extra_parameters)
 
     with :ok <- send_packet(client, payload) do
-      recv_packets(client, &DiscardMessage.prepare_messages/2, :infinity)
+      recv_packets(client, &DiscardMessage.prepare_messages/2, client.recv_timeout)
     end
   end
 
@@ -457,7 +459,7 @@ defmodule Bolty.Client do
     payload = LogoffMessage.encode(client.bolt_version)
 
     with :ok <- send_packet(client, payload) do
-      recv_packets(client, &__MODULE__.prepare_generic_messages/2, :infinity)
+      recv_packets(client, &__MODULE__.prepare_generic_messages/2, client.recv_timeout)
     end
   end
 
@@ -509,6 +511,9 @@ defmodule Bolty.Client do
       {:ok, message_record} ->
         recv_packets(client, prepare_messages, timeout, [message_record | messages])
 
+      # get_chunk_size/get_chunk already wrap a socket :timeout (and any other
+      # recv error) into a %Bolty.Error{code: :timeout}; the caller tears the
+      # connection down rather than reuse a desynced one.
       {:error, _} = error ->
         error
     end

--- a/lib/bolty/connection.ex
+++ b/lib/bolty/connection.ex
@@ -163,12 +163,27 @@ defmodule Bolty.Connection do
   def handle_status(_opts, %__MODULE__{in_transaction: true} = state), do: {:transaction, state}
   def handle_status(_opts, state), do: {:idle, state}
 
-  defp execute(statement, params, _opts, state) do
+  defp execute(statement, params, opts, state) do
     %__MODULE__{client: client} = state
+
+    # Per-query override of the connection-wide :recv_timeout. Applied to a local
+    # copy only, so it governs this call (RUN/PULL) without leaking into the
+    # pooled connection's state and affecting later queries.
+    client =
+      case Keyword.fetch(opts, :recv_timeout) do
+        {:ok, recv_timeout} -> %{client | recv_timeout: recv_timeout}
+        :error -> client
+      end
 
     case Client.run_statement(client, statement, params) do
       {:ok, statement_result} ->
         {:ok, statement_result}
+
+      # A recv timeout left the socket desynced (a late RUN/PULL response may still
+      # arrive); RESET-recovery would read the wrong bytes, so tear the connection
+      # down instead of returning it to the pool.
+      {:error, %Bolty.Error{code: :timeout} = error} ->
+        {:disconnect, error, state}
 
       {:error, %Bolty.Error{} = error} ->
         recover_from_failure(client, error, state)

--- a/test/bolty/timeout_test.exs
+++ b/test/bolty/timeout_test.exs
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Bolty.TimeoutTest do
+  @moduledoc """
+  Per-query / per-read timeouts (#74): the `:recv_timeout` option, its default,
+  per-query override, and the disconnect-on-timeout behaviour. The timeout path
+  is driven with a socket double so it is deterministic and needs no server.
+  """
+  use ExUnit.Case, async: true
+
+  alias Bolty.Client
+  alias Bolty.Client.Config
+
+  # A socket double whose `recv/3` always reports a socket timeout, recording the
+  # timeout value it was called with so we can assert what got threaded through.
+  defmodule TimingOutSock do
+    @moduledoc false
+    def start, do: Agent.start_link(fn -> :never_called end)
+    def send(_sock, _data), do: :ok
+
+    def recv(agent, _length, timeout) do
+      Agent.update(agent, fn _ -> timeout end)
+      {:error, :timeout}
+    end
+
+    def last_timeout(agent), do: Agent.get(agent, & &1)
+  end
+
+  defp client(agent, recv_timeout) do
+    %Client{
+      sock: {TimingOutSock, agent},
+      bolt_version: 5.0,
+      recv_timeout: recv_timeout,
+      policy: Bolty.Policy.Resolver.resolve(5.0, %{})
+    }
+  end
+
+  defp exec(client, opts) do
+    state = %Bolty.Connection{client: client, in_transaction: false}
+    query = %Bolty.Query{statement: "RETURN 1", extra: %{}}
+    Bolty.Connection.handle_execute(query, %{}, opts, state)
+  end
+
+  describe "Config" do
+    @base [auth: [username: "neo4j", password: "pw"]]
+
+    test "recv_timeout defaults to 15_000" do
+      assert {:ok, %Config{recv_timeout: 15_000}} = Config.new(@base)
+    end
+
+    test "recv_timeout is taken from the :recv_timeout option" do
+      assert {:ok, %Config{recv_timeout: 3_000}} = Config.new([recv_timeout: 3_000] ++ @base)
+
+      assert {:ok, %Config{recv_timeout: :infinity}} =
+               Config.new([recv_timeout: :infinity] ++ @base)
+    end
+  end
+
+  describe "timeout handling" do
+    test "a read timeout disconnects with %Bolty.Error{code: :timeout}" do
+      {:ok, agent} = TimingOutSock.start()
+
+      assert {:disconnect, %Bolty.Error{code: :timeout}, _state} =
+               exec(client(agent, 5_000), [])
+    end
+
+    test "the connection's recv_timeout is used by default" do
+      {:ok, agent} = TimingOutSock.start()
+
+      exec(client(agent, 5_000), [])
+
+      assert TimingOutSock.last_timeout(agent) == 5_000
+    end
+
+    test "a per-query :recv_timeout overrides the connection default" do
+      {:ok, agent} = TimingOutSock.start()
+
+      exec(client(agent, 5_000), recv_timeout: 250)
+
+      assert TimingOutSock.last_timeout(agent) == 250
+    end
+  end
+
+  describe "against a live server" do
+    @tag :core
+    test "connect stores the configured recv_timeout on the client" do
+      opts = [recv_timeout: 8_000] ++ Bolty.TestHelper.opts()
+      assert {:ok, client} = Client.connect(opts)
+      assert client.recv_timeout == 8_000
+      Client.disconnect(client)
+    end
+
+    @tag :core
+    test "a query with a generous per-query recv_timeout still succeeds" do
+      {:ok, conn} = Bolty.start_link([pool_size: 1] ++ Bolty.TestHelper.opts())
+      assert {:ok, _} = Bolty.query(conn, "RETURN 1 AS n", %{}, recv_timeout: 30_000)
+    end
+  end
+end


### PR DESCRIPTION
Closes #74.

## Problem
Every post-connect protocol read used `recv_packets(client, fun, :infinity)` — only the version handshake honoured `connect_timeout`. A stalled server or half-dead TCP connection hangs the checked-out caller indefinitely; DBConnection's queue timeout does not rescue a caller already executing.

## Change
- New **`:recv_timeout`** option (default **`15_000`**), parsed in `Client.Config`, stored on the `Client` struct, and threaded into **every** post-connect `recv` (HELLO/LOGON/RUN/PULL/BEGIN/COMMIT/ROLLBACK/RESET/DISCARD/LOGOFF) in place of `:infinity`.
- **Per-query override** via `opts[:recv_timeout]` in `handle_execute` — applied to a local copy of the client only, so it governs that RUN/PULL without leaking into the pooled connection's state.
- A timed-out read surfaces as **`{:error, %Bolty.Error{code: :timeout}}`** (the chunk layer already wraps `:timeout` via `Bolty.Error.wrap/2`) and **disconnects** the connection rather than RESET-recovering — a late RUN/PULL response may still arrive, so the socket is desynced and can't be safely reused.
- Documented on `start_link/1` and `query/4`.

## Semantics (why 15s is safe)
It's a **per-read socket-inactivity** timeout, not a whole-query timeout: the window resets on every chunk the server sends, so streaming a large result set is unaffected. It fires only when the server sends *no* bytes for the configured time. Queries that legitimately compute for a long time before returning any data can pass `recv_timeout: :infinity` (per query) or raise the connection default.

> **Behaviour change:** the default post-connect read timeout goes from `:infinity` to `15_000ms`. A query that produces no bytes for >15s now errors with `%Bolty.Error{code: :timeout}` unless `:recv_timeout` is raised.

## Tests
`test/bolty/timeout_test.exs` — deterministic, using a socket double whose `recv/3` reports a timeout and records the timeout value threaded to it:
- `Config` default (`15_000`) and `:recv_timeout` override (incl. `:infinity`)
- a read timeout → `{:disconnect, %Bolty.Error{code: :timeout}, _}`
- the connection default is used, and a per-query `:recv_timeout` overrides it
- (live) connect stores the configured `recv_timeout`; a query with a generous per-query timeout still succeeds

`mix format`, `mix compile --warnings-as-errors`, `mix dialyzer` (0 errors) all clean. The `#74`-relevant tests pass 3/3 across repeated runs.

Note: the suite has a **pre-existing** async flake in the message-encoder tests (unrelated to this change) — root-caused and filed on #75.