### PR TITLE
fix: reject unknown PackStream markers instead of silently misdecoding

### DIFF
--- a/lib/bolty/bolt_protocol/message_decoder.ex
+++ b/lib/bolty/bolt_protocol/message_decoder.ex
@@ -46,6 +46,12 @@ defmodule Bolty.BoltProtocol.MessageDecoder do
 
         {:ok, response} ->
           response
+
+        # Corrupt/undecodable server payload (e.g. an unknown marker). Raise the
+        # %Bolty.Error{} so the connection tears down rather than proceeding with
+        # a partially decoded message.
+        {:error, %Bolty.Error{} = error} ->
+          raise error
       end
 
     Bolty.Utils.Logger.log_message(:server, message_type, response)

--- a/lib/bolty/pack_stream/unpacker.ex
+++ b/lib/bolty/pack_stream/unpacker.ex
@@ -193,8 +193,23 @@ defmodule Bolty.PackStream.Unpacker do
     [int | unpack(rest)]
   end
 
-  def unpack(<<int::signed-integer, rest::binary>>) do
+  # Tiny integer: a single byte holding -16..127 (markers 0xF0..0xFF and
+  # 0x00..0x7F). Bounded explicitly so an unknown/reserved marker byte can't be
+  # silently misread as a tiny int.
+  def unpack(<<int::signed-integer, rest::binary>>) when int in -16..127 do
     [int | unpack(rest)]
+  end
+
+  # Unknown / reserved PackStream marker. Fail loudly rather than decode a corrupt
+  # or malicious byte as data. Thrown (not raised) so PackStream.unpack/1 surfaces
+  # it as {:error, %Bolty.Error{}} via its try/catch.
+  def unpack(<<marker, _rest::binary>>) do
+    throw(
+      Bolty.Error.wrap(__MODULE__, %{
+        code: :unknown_marker,
+        message: "unknown PackStream marker 0x" <> Integer.to_string(marker, 16)
+      })
+    )
   end
 
   # Local Date
@@ -268,7 +283,7 @@ defmodule Bolty.PackStream.Unpacker do
          @legacy_datetime_with_zone_offset_struct_size}
       ) do
     {[seconds, nanoseconds, zone_offset], rest} =
-      decode_struct(struct, @legacy_datetime_with_zone_id_struct_size)
+      decode_struct(struct, @legacy_datetime_with_zone_offset_struct_size)
 
     naive_dt =
       NaiveDateTime.add(
@@ -286,7 +301,7 @@ defmodule Bolty.PackStream.Unpacker do
         {@datetime_with_zone_offset_signature, struct, @datetime_with_zone_offset_struct_size}
       ) do
     {[seconds, nanoseconds, zone_offset], rest} =
-      decode_struct(struct, @legacy_datetime_with_zone_id_struct_size)
+      decode_struct(struct, @datetime_with_zone_offset_struct_size)
 
     naive_dt =
       NaiveDateTime.add(
@@ -328,6 +343,18 @@ defmodule Bolty.PackStream.Unpacker do
   def unpack({@vector_signature, struct, @vector_struct_size}) do
     {[type_marker, data], rest} = decode_struct(struct, @vector_struct_size)
     [decode_vector(type_marker, data) | rest]
+  end
+
+  # Unknown struct signature. Fail loudly (thrown, so PackStream.unpack/1 returns
+  # {:error, %Bolty.Error{}}) rather than crash with a FunctionClauseError on a
+  # corrupt or unsupported server structure.
+  def unpack({signature, _struct, _struct_size}) do
+    throw(
+      Bolty.Error.wrap(__MODULE__, %{
+        code: :unknown_marker,
+        message: "unknown PackStream struct signature 0x" <> Integer.to_string(signature, 16)
+      })
+    )
   end
 
   # Private

--- a/test/bolty/pack_stream_test.exs
+++ b/test/bolty/pack_stream_test.exs
@@ -868,4 +868,34 @@ defmodule Bolty.PackStreamTest do
       end
     end
   end
+
+  describe "Decode rejects unknown markers (#76)" do
+    test "an unknown/reserved marker byte returns {:error, :unknown_marker}" do
+      for marker <- [0xC4, 0xC5, 0xC6, 0xC7, 0xCF] do
+        assert {:error, %Bolty.Error{code: :unknown_marker}} = PackStream.unpack(<<marker>>)
+      end
+    end
+
+    test "an unknown marker mid-stream errors instead of decoding as a tiny int" do
+      # tiny list of 3, second element is a reserved marker (0xC4) not a tiny int.
+      assert {:error, %Bolty.Error{code: :unknown_marker}} =
+               PackStream.unpack(<<0x93, 0x01, 0xC4, 0x02>>)
+    end
+
+    test "an unknown struct signature returns {:error, :unknown_marker}" do
+      assert {:error, %Bolty.Error{code: :unknown_marker}} =
+               PackStream.unpack(<<0xB1, 0xFF, 0xC0>>)
+    end
+
+    test "unpack! raises %Bolty.Error{} on an unknown marker" do
+      assert_raise Bolty.Error, fn -> PackStream.unpack!(<<0xC4>>) end
+    end
+
+    test "tiny-int boundaries still decode" do
+      assert PackStream.unpack!(<<0x00>>) == [0]
+      assert PackStream.unpack!(<<0x7F>>) == [127]
+      assert PackStream.unpack!(<<0xF0>>) == [-16]
+      assert PackStream.unpack!(<<0xFF>>) == [-1]
+    end
+  end
 end


### PR DESCRIPTION
Closes #76.

## Problem
`unpacker.ex` had a catch-all `unpack(<<int::signed-integer, rest::binary>>)` that treated **any** unmatched byte — including reserved PackStream markers — as a tiny int. A corrupt or malicious server response degraded into silently wrong data instead of a decode error.

## Change
- **Bound the tiny-int clause** to its real range (`-16..127`, i.e. bytes `0x00..0x7F` / `0xF0..0xFF`) and add an explicit error clause that **throws `%Bolty.Error{code: :unknown_marker}`** for any unknown marker byte. Thrown (not raised) so `PackStream.unpack/1` surfaces it as `{:error, %Bolty.Error{}}` via its existing `try/catch`.
- **Same guard for unknown struct signatures** — these previously escaped `PackStream.unpack/1` as an uncaught `FunctionClauseError`, violating its `{:error,_} | {:ok,_}` contract. Now `{:error, :unknown_marker}` too.
- **`MessageDecoder.build_response`** now handles the `{:error, %Bolty.Error{}}` case by raising it, so a corrupt server message tears the connection down (via the execute rescue → disconnect) rather than `CaseClauseError`-ing or proceeding with a partial decode.
- **Fix the copy-pasted constant** — the legacy/regular datetime-with-zone-offset clauses used `@legacy_datetime_with_zone_id_struct_size` instead of their own `@legacy_datetime_with_zone_offset_struct_size` / `@datetime_with_zone_offset_struct_size` (same value `3` today, wrong symbol — would silently break if the sizes ever diverge).

## Tests
New `Decode rejects unknown markers` describe in `pack_stream_test.exs`:
- reserved marker bytes (`0xC4..0xC7`, `0xCF`) → `{:error, :unknown_marker}`
- an unknown marker mid-stream (inside a list) errors instead of decoding as a tiny int
- unknown struct signature → `{:error, :unknown_marker}`
- `unpack!` raises `%Bolty.Error{}`
- tiny-int boundaries (`0`, `127`, `-16`, `-1`) still decode

The StreamData property suite from #75 continues to pass (valid values round-trip). Datetime round-trips (integration) confirm the constant fix. `mix format`, `mix compile --warnings-as-errors`, `mix dialyzer` (0 errors) all clean; bare `mix test` 208 passed, integration 298 passed.