### PR TITLE
test: make bolty_test serial to stop async DB-truncate flake

### DIFF
--- a/test/bolty_test.exs
+++ b/test/bolty_test.exs
@@ -2,7 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule BoltyTest do
-  use ExUnit.Case, async: true
+  # async: false — this module's `:truncate` setup wipes the whole database
+  # (`MATCH (n) DETACH DELETE n`, see truncate/1). Run concurrently it would
+  # delete data out from under other integration tests mid-run (e.g. a committed
+  # node another module is about to read), causing intermittent failures. Kept
+  # serial so the global wipe never overlaps another test. Other integration
+  # modules scope their own cleanup (or design around it) and stay async.
+  use ExUnit.Case, async: false
 
   @moduletag :integration
 

--- a/test/support/database.ex
+++ b/test/support/database.ex
@@ -1,8 +1,0 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
-# SPDX-License-Identifier: Apache-2.0
-
-defmodule Bolty.Test.Support.Database do
-  def clear(conn) do
-    Bolty.query!(conn, "MATCH (n) DETACH DELETE n")
-  end
-end


### PR DESCRIPTION
## Problem
CI intermittently failed a single version job (e.g. Bolt 5.1) on `transaction_test`'s isolation check: a node it committed came back as 0 rows because a **concurrent** module wiped the whole database mid-test.

Root cause: `BoltyTest`'s `:truncate` setup runs a **global** `MATCH (n) DETACH DELETE n` before each test, and the module is `async: true`. That "clean slate for me" is really "delete everyone's data", so when it overlaps another integration module it deletes data out from under it.

## Why only this module
It's the **only** module doing a global wipe:
- `transaction_test` — `setup [:connect]` only; deletes just its own `:XactRollback` / `:XactCommit` nodes.
- `connection_recovery_test` — uses constraints + unique labels, deliberately designed around the wipe.

So making just `BoltyTest` `async: false` removes the overlap (ExUnit runs sync modules without any other module running concurrently) while the well-behaved modules stay `async: true`.

## Changes
- `BoltyTest` → `async: false`, with a comment explaining why.
- Delete `test/support/database.ex` — `Test.Support.Database.clear/1` was a second global-truncate helper with **zero callers** (dead footgun).

## Verification
`mix format`, bare `mix test` (208 passed, no DB), integration `BOLT_TCP_PORT=7687 mix test` **5×** (298 passed each), `reuse lint` clean.

Follow-up (not this PR): migrating `BoltyTest` to label-scoped cleanup like `transaction_test` would let it go back to `async: true`.