### PR TITLE
feat: represent Bolt versions as strings/tuples, not floats (0.3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ opts = [
     prefix: :default
 ]
 
-# Pin to a specific Bolt version:
-opts = [versions: [5.4]] ++ opts
+# Pin to a specific Bolt version (versions are strings; floats are deprecated):
+opts = [versions: ["5.4"]] ++ opts
 
 # Offer multiple versions as ranges (handshake has 4 slots — ranges cover more):
 opts = [versions: [{5, 6..8}, {5, 0..4}]] ++ opts
@@ -166,7 +166,7 @@ Bolty negotiates the highest mutually-supported Bolt version during connection. 
 ```elixir
 iex> Bolty.connection_info(conn)
 %{
-  bolt_version: 5.8,
+  bolt_version: "5.8",
   server_version: "Neo4j/5.26.28",
   policy: %Bolty.Policy{
     datetime: :evolved,
@@ -217,8 +217,8 @@ opts = [versions: [{5, 7..8}]] ++ opts
 # Require the renamed notification field (Bolt 5.6+)
 opts = [versions: [{5, 6..8}]] ++ opts
 
-# Target a single known version
-opts = [versions: [5.4]] ++ opts
+# Target a single known version (a string; a float like `5.4` is deprecated)
+opts = [versions: ["5.4"]] ++ opts
 
 # Offer two disjoint ranges when you want broad compatibility but must skip 5.5
 opts = [versions: [{5, 6..8}, {5, 0..4}]] ++ opts

--- a/lib/bolty.ex
+++ b/lib/bolty.ex
@@ -24,7 +24,7 @@ defmodule Bolty do
           | {:hostname, String.t()}
           | {:port, :inet.port_number()}
           | {:scheme, :inet.port_number()}
-          | {:versions, list(float())}
+          | {:versions, list(String.t() | float())}
           | {:auth, basic_auth()}
           | {:user_agent, String.t()}
           | {:notifications_minimum_severity, String.t()}
@@ -58,7 +58,11 @@ defmodule Bolty do
 
   * `:scheme` - Is one among neo4j, neo4j+s, neo4j+ssc, bolt, bolt+s, bolt+ssc (default: bolt+s).
 
-  * `:versions` - List of bolt versions you want to be negotiated with the server.
+  * `:versions` - List of Bolt versions to offer during negotiation, as strings
+   (`["5.4", "6.0"]`) or `{major, minor..minor}` range tuples (`[{5, 6..8}]`).
+   Floats (`[5.4]`) are **deprecated** — they can't distinguish `5.10` from `5.1`
+   — and are still accepted with a one-time warning. (Default: the latest
+   supported versions.)
 
   * `:auth` - The basic authentication scheme
 
@@ -211,12 +215,12 @@ defmodule Bolty do
   ```elixir
   Bolty.transaction(Bolt, fn conn ->
     Bolty.connection_info(conn)
-    # => %{bolt_version: 5.8, server_version: "Neo4j/5.26.27", policy: %Bolty.Policy{...}}
+    # => %{bolt_version: "5.8", server_version: "Neo4j/5.26.27", policy: %Bolty.Policy{...}}
   end)
   ```
   """
   @spec connection_info(conn()) :: %{
-          bolt_version: float(),
+          bolt_version: String.t(),
           server_version: String.t(),
           policy: Bolty.Policy.t()
         }

--- a/lib/bolty/bolt_protocol/message/begin_message.ex
+++ b/lib/bolty/bolt_protocol/message/begin_message.ex
@@ -9,7 +9,7 @@ defmodule Bolty.BoltProtocol.Message.BeginMessage do
   @signature 0x11
 
   def encode(bolt_version, extra_parameters)
-      when is_float(bolt_version) and bolt_version >= 3.0 do
+      when is_tuple(bolt_version) and bolt_version >= {3, 0} do
     message = [get_extra_parameters(extra_parameters)]
     MessageEncoder.encode(@signature, message)
   end

--- a/lib/bolty/bolt_protocol/message/commit_message.ex
+++ b/lib/bolty/bolt_protocol/message/commit_message.ex
@@ -8,7 +8,7 @@ defmodule Bolty.BoltProtocol.Message.CommitMessage do
 
   @signature 0x12
 
-  def encode(bolt_version) when is_float(bolt_version) and bolt_version >= 3.0 do
+  def encode(bolt_version) when is_tuple(bolt_version) and bolt_version >= {3, 0} do
     message = []
     MessageEncoder.encode(@signature, message)
   end

--- a/lib/bolty/bolt_protocol/message/discard_message.ex
+++ b/lib/bolty/bolt_protocol/message/discard_message.ex
@@ -9,7 +9,7 @@ defmodule Bolty.BoltProtocol.Message.DiscardMessage do
   @signature 0x2F
 
   def encode(bolt_version, extra_parameters)
-      when is_float(bolt_version) and bolt_version >= 4.0 do
+      when is_tuple(bolt_version) and bolt_version >= {4, 0} do
     message = [get_extra_parameters(extra_parameters)]
     MessageEncoder.encode(@signature, message)
   end

--- a/lib/bolty/bolt_protocol/message/goodbye_message.ex
+++ b/lib/bolty/bolt_protocol/message/goodbye_message.ex
@@ -8,7 +8,7 @@ defmodule Bolty.BoltProtocol.Message.GoodbyeMessage do
 
   @signature 0x02
 
-  def encode(bolt_version) when is_float(bolt_version) and bolt_version >= 3.0 do
+  def encode(bolt_version) when is_tuple(bolt_version) and bolt_version >= {3, 0} do
     MessageEncoder.encode(@signature, [])
   end
 

--- a/lib/bolty/bolt_protocol/message/hello_message.ex
+++ b/lib/bolty/bolt_protocol/message/hello_message.ex
@@ -10,7 +10,7 @@ defmodule Bolty.BoltProtocol.Message.HelloMessage do
 
   @signature 0x01
 
-  def encode(bolt_version, fields) when is_float(bolt_version) and bolt_version >= 5.1 do
+  def encode(bolt_version, fields) when is_tuple(bolt_version) and bolt_version >= {5, 1} do
     policy = Keyword.get(fields, :policy, %Bolty.Policy{})
 
     message = [
@@ -23,7 +23,7 @@ defmodule Bolty.BoltProtocol.Message.HelloMessage do
     MessageEncoder.encode(@signature, message)
   end
 
-  def encode(bolt_version, fields) when is_float(bolt_version) and bolt_version >= 3.0 do
+  def encode(bolt_version, fields) when is_tuple(bolt_version) and bolt_version >= {3, 0} do
     message = [Map.merge(get_auth_params(fields), get_user_agent(bolt_version, fields))]
     MessageEncoder.encode(@signature, message)
   end

--- a/lib/bolty/bolt_protocol/message/logoff_message.ex
+++ b/lib/bolty/bolt_protocol/message/logoff_message.ex
@@ -8,7 +8,7 @@ defmodule Bolty.BoltProtocol.Message.LogoffMessage do
 
   @signature 0x6B
 
-  def encode(bolt_version) when is_float(bolt_version) and bolt_version >= 5.1 do
+  def encode(bolt_version) when is_tuple(bolt_version) and bolt_version >= {5, 1} do
     MessageEncoder.encode(@signature, [])
   end
 

--- a/lib/bolty/bolt_protocol/message/logon_message.ex
+++ b/lib/bolty/bolt_protocol/message/logon_message.ex
@@ -10,7 +10,7 @@ defmodule Bolty.BoltProtocol.Message.LogonMessage do
 
   @signature 0x6A
 
-  def encode(bolt_version, fields) when is_float(bolt_version) and bolt_version >= 3.0 do
+  def encode(bolt_version, fields) when is_tuple(bolt_version) and bolt_version >= {3, 0} do
     message = [get_auth_params(fields)]
     MessageEncoder.encode(@signature, message)
   end

--- a/lib/bolty/bolt_protocol/message/pull_message.ex
+++ b/lib/bolty/bolt_protocol/message/pull_message.ex
@@ -11,7 +11,7 @@ defmodule Bolty.BoltProtocol.Message.PullMessage do
   @signature 0x3F
 
   def encode(bolt_version, extra_parameters)
-      when is_float(bolt_version) and bolt_version >= 4.0 do
+      when is_tuple(bolt_version) and bolt_version >= {4, 0} do
     message = [get_extra_parameters(extra_parameters)]
     MessageEncoder.encode(@signature, message)
   end

--- a/lib/bolty/bolt_protocol/message/reset_message.ex
+++ b/lib/bolty/bolt_protocol/message/reset_message.ex
@@ -8,7 +8,7 @@ defmodule Bolty.BoltProtocol.Message.ResetMessage do
 
   @signature 0x0F
 
-  def encode(bolt_version) when is_float(bolt_version) and bolt_version >= 3.0 do
+  def encode(bolt_version) when is_tuple(bolt_version) and bolt_version >= {3, 0} do
     MessageEncoder.encode(@signature, [])
   end
 

--- a/lib/bolty/bolt_protocol/message/rollback_message.ex
+++ b/lib/bolty/bolt_protocol/message/rollback_message.ex
@@ -8,7 +8,7 @@ defmodule Bolty.BoltProtocol.Message.RollbackMessage do
 
   @signature 0x13
 
-  def encode(bolt_version) when is_float(bolt_version) and bolt_version >= 3.0 do
+  def encode(bolt_version) when is_tuple(bolt_version) and bolt_version >= {3, 0} do
     message = []
     MessageEncoder.encode(@signature, message)
   end

--- a/lib/bolty/bolt_protocol/message/run_message.ex
+++ b/lib/bolty/bolt_protocol/message/run_message.ex
@@ -12,7 +12,7 @@ defmodule Bolty.BoltProtocol.Message.RunMessage do
   def encode(bolt_version, query, parameters, extra_parameters, policy \\ %Policy{})
 
   def encode(bolt_version, query, parameters, extra_parameters, policy)
-      when is_float(bolt_version) and bolt_version >= 3.0 do
+      when is_tuple(bolt_version) and bolt_version >= {3, 0} do
     message = [query, parameters, get_extra_parameters(extra_parameters)]
     MessageEncoder.encode(@signature, message, policy)
   end

--- a/lib/bolty/bolt_protocol/versions.ex
+++ b/lib/bolty/bolt_protocol/versions.ex
@@ -4,7 +4,25 @@
 defmodule Bolty.BoltProtocol.Versions do
   @moduledoc false
 
-  @available_bolt_versions [5.0, 5.1, 5.2, 5.3, 5.4, 5.6, 5.7, 5.8, 6.0]
+  # Versions are represented internally as `{major, minor}` integer tuples, not
+  # floats: a float can't distinguish 5.10 from 5.1, and tuple term-ordering
+  # compares as versions (`{5, 10} > {5, 6}`). Floats are accepted at the public
+  # `:versions` boundary for backwards compatibility (see `parse/1`) but never
+  # flow further in.
+  @available_bolt_versions [
+    {5, 0},
+    {5, 1},
+    {5, 2},
+    {5, 3},
+    {5, 4},
+    {5, 6},
+    {5, 7},
+    {5, 8},
+    {6, 0}
+  ]
+
+  @type version :: {non_neg_integer(), non_neg_integer()}
+  @type version_range :: {non_neg_integer(), Range.t()}
 
   def available_versions() do
     @available_bolt_versions
@@ -15,86 +33,87 @@ defmodule Bolty.BoltProtocol.Versions do
     |> Enum.take(4)
   end
 
-  def to_bytes(version) when is_float(version) do
-    [major | [minor]] =
+  @doc """
+  Normalise a user-supplied `:versions` entry to the internal `{major, minor}`
+  form. Accepts the string form (`"5.4"`), an explicit `{major, minor}` /
+  `{major, minor..minor}` tuple, or — deprecated — a float (`5.4`) or bare major
+  integer (`5`). Returns `{version, deprecated?}` so the caller can emit a single
+  deprecation warning.
+  """
+  @spec parse(String.t() | float() | integer() | version() | version_range()) ::
+          {version() | version_range(), boolean()}
+  def parse(version) when is_binary(version) do
+    [major, minor] = version |> String.split(".") |> Enum.map(&String.to_integer/1)
+    {{major, minor}, false}
+  end
+
+  def parse(version) when is_float(version) do
+    [major, minor] =
       version |> Float.to_string() |> String.split(".") |> Enum.map(&String.to_integer/1)
 
+    {{major, minor}, true}
+  end
+
+  def parse(version) when is_integer(version), do: {{version, 0}, true}
+
+  def parse({major, minor} = version) when is_integer(major) and is_integer(minor),
+    do: {version, false}
+
+  def parse({major, %Range{}} = version) when is_integer(major), do: {version, false}
+
+  @doc "Render a `{major, minor}` version as its public string form, e.g. `\"5.8\"`."
+  @spec format(version()) :: String.t()
+  def format({major, minor}), do: "#{major}.#{minor}"
+
+  def to_bytes({major, minor}) when is_integer(minor) do
     <<0, 0>> <> <<minor, major>>
   end
 
-  def to_bytes(version) when is_integer(version) do
-    to_bytes(version + 0.0)
-  end
-
-  def to_bytes(version) when is_tuple(version) do
-    {major, minor_or_range} = version
-
-    cond do
-      is_integer(minor_or_range) ->
-        <<0, 0>> <> <<minor_or_range, major>>
-
-      is_struct(minor_or_range, Range) ->
-        minor = List.last(Range.to_list(minor_or_range))
-        previous = Range.size(minor_or_range) - 1
-        <<0>> <> <<previous, minor, major>>
-    end
+  def to_bytes({major, %Range{} = minor_range}) do
+    minor = List.last(Range.to_list(minor_range))
+    previous = Range.size(minor_range) - 1
+    <<0>> <> <<previous, minor, major>>
   end
 
   def rangeify(list) when is_list(list) do
-    Enum.into(list, [], fn version ->
+    list
+    |> Enum.reduce([], fn {major, minor} = value, acc ->
       cond do
-        is_float(version) ->
-          [major | [minor]] =
-            version |> Float.to_string() |> String.split(".") |> Enum.map(&String.to_integer/1)
+        acc == [] ->
+          [value]
 
-          {major, minor}
+        major < 4 ->
+          [value | acc]
 
-        is_integer(version) ->
-          {version, 0}
+        major == 4 and minor < 3 ->
+          [value | acc]
+
+        true ->
+          [{prev_major, prev_minor_or_range} | tail] = acc
+
+          cond do
+            major < prev_major ->
+              [value | acc]
+
+            is_integer(prev_minor_or_range) ->
+              if minor + 1 == prev_minor_or_range do
+                [{prev_major, Range.new(minor, prev_minor_or_range)} | tail]
+              else
+                [value | acc]
+              end
+
+            true ->
+              if minor + 1 == prev_minor_or_range.first do
+                [
+                  {prev_major, Range.new(minor, List.last(Range.to_list(prev_minor_or_range)))}
+                  | tail
+                ]
+              else
+                [value | acc]
+              end
+          end
       end
     end)
-    |> Enum.reduce(
-      [],
-      fn value, acc ->
-        {major, minor} = value
-
-        cond do
-          acc == [] ->
-            [value]
-
-          major < 4 ->
-            [value | acc]
-
-          major == 4 and minor < 3 ->
-            [value | acc]
-
-          true ->
-            [{prev_major, prev_minor_or_range} | tail] = acc
-
-            cond do
-              major < prev_major ->
-                [value | acc]
-
-              is_integer(prev_minor_or_range) ->
-                if minor + 1 == prev_minor_or_range do
-                  [{prev_major, Range.new(minor, prev_minor_or_range)} | tail]
-                else
-                  [value | acc]
-                end
-
-              true ->
-                if minor + 1 == prev_minor_or_range.first do
-                  [
-                    {prev_major, Range.new(minor, List.last(Range.to_list(prev_minor_or_range)))}
-                    | tail
-                  ]
-                else
-                  [value | acc]
-                end
-            end
-        end
-      end
-    )
     |> Enum.reverse()
   end
 end

--- a/lib/bolty/client.ex
+++ b/lib/bolty/client.ex
@@ -147,8 +147,28 @@ defmodule Bolty.Client do
     end
 
     def get_versions(opts) do
-      versions = Keyword.get(opts, :versions) || Versions.latest_versions()
-      ((versions |> Enum.into([])) ++ [0, 0, 0]) |> Enum.take(4) |> Enum.sort(&>=/2)
+      case Keyword.get(opts, :versions) do
+        nil ->
+          Versions.latest_versions()
+
+        versions ->
+          {parsed, deprecated_float?} =
+            Enum.map_reduce(versions, false, fn version, dep? ->
+              {canonical, float?} = Versions.parse(version)
+              {canonical, dep? or float?}
+            end)
+
+          if deprecated_float? do
+            require Logger
+
+            Logger.warning(
+              "bolty: passing float Bolt versions to :versions is deprecated and will be " <>
+                "removed; use strings like \"5.4\" (a float can't distinguish 5.10 from 5.1)."
+            )
+          end
+
+          (parsed ++ [{0, 0}, {0, 0}, {0, 0}]) |> Enum.take(4) |> Enum.sort(&>=/2)
+      end
     end
   end
 
@@ -304,7 +324,7 @@ defmodule Bolty.Client do
          encode_version <- recv_packets(client, config.connect_timeout),
          version <- decode_version(encode_version) do
       case version do
-        +0.0 -> {:error, Bolty.Error.wrap(__MODULE__, :version_negotiation_error)}
+        {0, 0} -> {:error, Bolty.Error.wrap(__MODULE__, :version_negotiation_error)}
         _ -> {:ok, %{client | bolt_version: version}}
       end
     else
@@ -475,7 +495,7 @@ defmodule Bolty.Client do
 
   defp decode_version(<<0, 0, minor::unsigned-integer, major::unsigned-integer>>)
        when is_integer(major) and is_integer(minor) do
-    Float.round(major + minor / 10.0, 1)
+    {major, minor}
   end
 
   def send_packet(client, payload) do

--- a/lib/bolty/connection.ex
+++ b/lib/bolty/connection.ex
@@ -7,6 +7,7 @@ defmodule Bolty.Connection do
 
   import Bolty.BoltProtocol.ServerResponse
 
+  alias Bolty.BoltProtocol.Versions
   alias Bolty.Client
   alias Bolty.Policy
   alias Bolty.Response
@@ -45,7 +46,7 @@ defmodule Bolty.Connection do
           %{duration: System.monotonic_time() - start},
           %{
             db_system: "neo4j",
-            bolt_version: client.bolt_version,
+            bolt_version: Versions.format(client.bolt_version),
             server_version: new_state.server_version,
             connection_id: new_state.connection_id
           }
@@ -103,7 +104,7 @@ defmodule Bolty.Connection do
   @impl true
   def handle_execute(%Bolty.ConnectionInfo{} = query, _params, _opts, state) do
     result = %{
-      bolt_version: state.client.bolt_version,
+      bolt_version: Versions.format(state.client.bolt_version),
       server_version: state.server_version,
       policy: state.client.policy
     }
@@ -248,14 +249,15 @@ defmodule Bolty.Connection do
     do_init(client.bolt_version, client, opts)
   end
 
-  defp do_init(bolt_version, client, opts) when is_float(bolt_version) and bolt_version >= 5.1 do
+  defp do_init(bolt_version, client, opts)
+       when is_tuple(bolt_version) and bolt_version >= {5, 1} do
     with {:ok, response_hello} <- Client.send_hello(client, opts),
          {:ok, _response_logon} <- Client.send_logon(client, opts) do
       {:ok, response_hello}
     end
   end
 
-  defp do_init(bolt_version, client, opts) when is_float(bolt_version) do
+  defp do_init(bolt_version, client, opts) when is_tuple(bolt_version) do
     Client.send_hello(client, opts)
   end
 

--- a/lib/bolty/policy/resolver.ex
+++ b/lib/bolty/policy/resolver.ex
@@ -23,7 +23,7 @@ defmodule Bolty.Policy.Resolver do
   `server_metadata` is the raw map returned by HELLO (keys are strings:
   `"server"`, `"hints"`, `"connection_id"`, etc.).
   """
-  @spec resolve(float() | nil, map()) :: Policy.t()
+  @spec resolve({non_neg_integer(), non_neg_integer()} | nil, map()) :: Policy.t()
   def resolve(bolt_version, server_metadata) when is_map(server_metadata) do
     server_version = Map.get(server_metadata, "server")
 
@@ -40,7 +40,7 @@ defmodule Bolty.Policy.Resolver do
   # Bolt 5.x uses evolved DateTime struct tags (0x49/0x69).
   # Bolt 4.x and below (no longer supported) used :legacy.
   defp put_datetime(policy, bolt_version, _server_version)
-       when is_float(bolt_version) and bolt_version >= 5.0 do
+       when is_tuple(bolt_version) and bolt_version >= {5, 0} do
     %{policy | datetime: :evolved}
   end
 
@@ -48,7 +48,7 @@ defmodule Bolty.Policy.Resolver do
 
   # Bolt 5.6 renamed the HELLO field for disabled notification categories.
   defp put_notifications_field(policy, bolt_version, _server_version)
-       when is_float(bolt_version) and bolt_version >= 5.6 do
+       when is_tuple(bolt_version) and bolt_version >= {5, 6} do
     %{policy | notifications_field: :notifications_disabled_classifications}
   end
 
@@ -57,7 +57,7 @@ defmodule Bolty.Policy.Resolver do
   # Bolt 5.7 switched to GQL-compliant FAILURE responses: neo4j_code/description
   # instead of code/message.
   defp put_gql_errors(policy, bolt_version, _server_version)
-       when is_float(bolt_version) and bolt_version >= 5.7 do
+       when is_tuple(bolt_version) and bolt_version >= {5, 7} do
     %{policy | gql_errors: true}
   end
 
@@ -65,7 +65,7 @@ defmodule Bolty.Policy.Resolver do
 
   # Bolt 6.0 introduced the Vector PackStream struct (signature 0x56).
   defp put_vectors(policy, bolt_version, _server_version)
-       when is_float(bolt_version) and bolt_version >= 6.0 do
+       when is_tuple(bolt_version) and bolt_version >= {6, 0} do
     %{policy | vectors: true}
   end
 
@@ -76,7 +76,7 @@ defmodule Bolty.Policy.Resolver do
   # opt into an explicit `CYPHER 5` prefix now that 2026.02+ servers default the
   # query language to Cypher 25.
   defp put_cypher_5(policy, bolt_version, _server_version)
-       when is_float(bolt_version) and bolt_version >= 5.0 do
+       when is_tuple(bolt_version) and bolt_version >= {5, 0} do
     %{policy | cypher_5: true}
   end
 

--- a/lib/mix/tasks/test.matrix.ex
+++ b/lib/mix/tasks/test.matrix.ex
@@ -36,8 +36,7 @@ defmodule Mix.Tasks.Test.Matrix do
 
     per_version_results =
       Enum.map(versions, fn version ->
-        version_str = Float.to_string(version)
-        port = if trunc(version) >= 6, do: bolt6_port, else: default_port
+        {version_str, port} = version_env(version, default_port, bolt6_port)
         Mix.shell().info([:bright, "\n── Bolt #{version_str} (port #{port}) ──\n"])
 
         {_, status} =
@@ -81,5 +80,21 @@ defmodule Mix.Tasks.Test.Matrix do
     if failures != "" do
       Mix.raise("Bolt version(s) failed: #{failures}")
     end
+  end
+
+  @doc """
+  Maps a `{major, minor}` version to the `{version_string, port}` a per-version
+  `mix test` run should use: the string form for `BOLT_VERSIONS`, and the Bolt 6
+  port for `major >= 6`, otherwise the default port. Pure — split out from the
+  `System.cmd` loop so it can be unit-tested.
+  """
+  @spec version_env(
+          {non_neg_integer(), non_neg_integer()},
+          String.t(),
+          String.t()
+        ) :: {String.t(), String.t()}
+  def version_env({major, _minor} = version, default_port, bolt6_port) do
+    port = if major >= 6, do: bolt6_port, else: default_port
+    {Bolty.BoltProtocol.Versions.format(version), port}
   end
 end

--- a/test/bolty/bolt_protocol/message/begin_message_test.exs
+++ b/test/bolty/bolt_protocol/message/begin_message_test.exs
@@ -9,14 +9,14 @@ defmodule Bolty.BoltProtocol.Message.BeginMessageTest do
   describe "BeginMessage.encode/2" do
     @tag :core
     test "coding without parameters" do
-      bolt_version = 3.0
+      bolt_version = {3, 0}
 
       assert <<0, 3, 177, 17, 160, 0, 0>> == BeginMessage.encode(bolt_version, %{})
     end
 
     @tag :core
     test "coding with parameters" do
-      bolt_version = 3.0
+      bolt_version = {3, 0}
 
       assert <<0, 38, 177, 17, 164, 137, 98, 111, 111, 107, 109, 97, 114, 107, 115, 144, 130, 100,
                98, 192, 132, 109, 111, 100, 101, 129, 119, 139, 116, 120, 95, 109, 101, 116, 97,
@@ -31,7 +31,7 @@ defmodule Bolty.BoltProtocol.Message.BeginMessageTest do
 
     @tag :core
     test "coding with version < 3 of bolt" do
-      bolt_version = 2.0
+      bolt_version = {2, 0}
 
       assert {:error,
               %Bolty.Error{

--- a/test/bolty/bolt_protocol/message/commit_message_test.exs
+++ b/test/bolty/bolt_protocol/message/commit_message_test.exs
@@ -9,14 +9,14 @@ defmodule Bolty.BoltProtocol.Message.CommitMessageTest do
   describe "CommitMessage.encode/1" do
     @tag :core
     test "coding with version >= 3 of bolt" do
-      bolt_version = 3.0
+      bolt_version = {3, 0}
 
       assert <<0, 2, 176, 18, 0, 0>> == CommitMessage.encode(bolt_version)
     end
 
     @tag :core
     test "coding with version < 3 of bolt" do
-      bolt_version = 1.0
+      bolt_version = {1, 0}
 
       assert {:error,
               %Bolty.Error{

--- a/test/bolty/bolt_protocol/message/goodbye_message_test.exs
+++ b/test/bolty/bolt_protocol/message/goodbye_message_test.exs
@@ -9,14 +9,14 @@ defmodule Bolty.BoltProtocol.Message.GoodbyeMessageTest do
   describe "GoodbyeMessage.encode/1" do
     @tag :core
     test "coding with version >= 3 of bolt" do
-      bolt_version = 3.0
+      bolt_version = {3, 0}
 
       assert <<0, 2, 176, 2, 0, 0>> == GoodbyeMessage.encode(bolt_version)
     end
 
     @tag :core
     test "coding with version < 3 of bolt" do
-      bolt_version = 1.0
+      bolt_version = {1, 0}
 
       assert {:error,
               %Bolty.Error{

--- a/test/bolty/bolt_protocol/message/logoff_message_test.exs
+++ b/test/bolty/bolt_protocol/message/logoff_message_test.exs
@@ -9,14 +9,14 @@ defmodule Bolty.BoltProtocol.Message.LogoffMessageTest do
   describe "LogoffMessage.encode/1" do
     @tag :core
     test "coding with version >= 5.1 of bolt" do
-      bolt_version = 5.1
+      bolt_version = {5, 1}
 
       assert <<0, 2, 176, 107, 0, 0>> == LogoffMessage.encode(bolt_version)
     end
 
     @tag :core
     test "coding with version <= 2 of bolt" do
-      bolt_version = 2.0
+      bolt_version = {2, 0}
 
       assert {:error,
               %Bolty.Error{

--- a/test/bolty/bolt_protocol/message/reset_message_test.exs
+++ b/test/bolty/bolt_protocol/message/reset_message_test.exs
@@ -9,13 +9,13 @@ defmodule Bolty.BoltProtocol.Message.ResetMessageTest do
   describe "ResetMessage.encode/1" do
     @tag :core
     test "coding with version >= 3.0 of bolt" do
-      bolt_version = 3.0
+      bolt_version = {3, 0}
       assert <<0, 2, 176, 15, 0, 0>> == ResetMessage.encode(bolt_version)
     end
 
     @tag :core
     test "coding with version <= 2 of bolt" do
-      bolt_version = 2.0
+      bolt_version = {2, 0}
 
       assert {:error,
               %Bolty.Error{

--- a/test/bolty/bolt_protocol/message_encoder_test.exs
+++ b/test/bolty/bolt_protocol/message_encoder_test.exs
@@ -24,63 +24,63 @@ defmodule Bolty.BoltProtocol.Message.MessageEncoderTest do
 
   describe "Encode HELLO" do
     test "without params" do
-      assert <<0x0, _, 0xB1, 0x1, _::binary>> = HelloMessage.encode(5.0, [])
+      assert <<0x0, _, 0xB1, 0x1, _::binary>> = HelloMessage.encode({5, 0}, [])
     end
 
     test "with params" do
       assert <<0x0, _, 0xB1, 0x1, _::binary>> =
-               HelloMessage.encode(5.0, user_agent: "user_agent_test")
+               HelloMessage.encode({5, 0}, user_agent: "user_agent_test")
     end
 
     test "with auth" do
       assert <<_, _, _, 0x01, _::binary>> =
-               HelloMessage.encode(5.0, auth: [username: "hello", password: "hellopw"])
+               HelloMessage.encode({5, 0}, auth: [username: "hello", password: "hellopw"])
     end
   end
 
   describe "Encode BEGIN" do
     test "without params" do
-      assert <<_, _, _, 0x11, _::binary>> = BeginMessage.encode(5.0, %{})
+      assert <<_, _, _, 0x11, _::binary>> = BeginMessage.encode({5, 0}, %{})
     end
 
     test "with params" do
-      assert <<_, _, _, 0x11, _::binary>> = BeginMessage.encode(5.0, %{mode: "w"})
+      assert <<_, _, _, 0x11, _::binary>> = BeginMessage.encode({5, 0}, %{mode: "w"})
     end
   end
 
   describe "Encode COMMIT" do
     test "without params" do
-      assert <<0x0, 0x2, 0xB0, 0x12, 0x0, 0x0>> == CommitMessage.encode(5.0)
+      assert <<0x0, 0x2, 0xB0, 0x12, 0x0, 0x0>> == CommitMessage.encode({5, 0})
     end
   end
 
   describe "Encode DISCARD" do
     test "without params" do
-      assert <<_, _, _, 0x2F, _::binary>> = DiscardMessage.encode(5.0, %{})
+      assert <<_, _, _, 0x2F, _::binary>> = DiscardMessage.encode({5, 0}, %{})
     end
   end
 
   describe "Encode GOODBYE" do
     test "without params" do
-      assert <<_, _, _, 0x02, _::binary>> = GoodbyeMessage.encode(5.0)
+      assert <<_, _, _, 0x02, _::binary>> = GoodbyeMessage.encode({5, 0})
     end
   end
 
   describe "Encode ROLLBACK" do
     test "without params" do
-      assert <<0x0, 0x2, 0xB0, 0x13, 0x0, 0x0>> = RollbackMessage.encode(5.0)
+      assert <<0x0, 0x2, 0xB0, 0x13, 0x0, 0x0>> = RollbackMessage.encode({5, 0})
     end
   end
 
   describe "Encode PULL" do
     test "without params" do
-      assert <<_, _, _, 0x3F, _::binary>> = PullMessage.encode(5.0, %{})
+      assert <<_, _, _, 0x3F, _::binary>> = PullMessage.encode({5, 0}, %{})
     end
   end
 
   describe "Encode RESET" do
     test "without params" do
-      assert <<0x0, 0x2, 0xB0, 0xF, 0x0, 0x0>> == ResetMessage.encode(5.0)
+      assert <<0x0, 0x2, 0xB0, 0xF, 0x0, 0x0>> == ResetMessage.encode({5, 0})
     end
   end
 
@@ -90,7 +90,7 @@ defmodule Bolty.BoltProtocol.Message.MessageEncoderTest do
                160, 164, 137, 98, 111, 111, 107, 109, 97, 114, 107, 115, 144, 130, 100, 98, 192,
                132, 109, 111, 100, 101, 129, 119, 139, 116, 120, 95, 109, 101, 116, 97, 100, 97,
                116, 97, 192, 0, 0>> ==
-               RunMessage.encode(5.0, "RETURN 1 AS num", %{}, %{})
+               RunMessage.encode({5, 0}, "RETURN 1 AS num", %{}, %{})
     end
 
     test "with params" do
@@ -98,7 +98,7 @@ defmodule Bolty.BoltProtocol.Message.MessageEncoderTest do
                32, 110, 117, 109, 161, 131, 110, 117, 109, 5, 164, 137, 98, 111, 111, 107, 109,
                97, 114, 107, 115, 144, 130, 100, 98, 192, 132, 109, 111, 100, 101, 129, 119, 139,
                116, 120, 95, 109, 101, 116, 97, 100, 97, 116, 97, 192, 0, 0>> ==
-               RunMessage.encode(5.0, "RETURN $num AS num", %{num: 5}, %{})
+               RunMessage.encode({5, 0}, "RETURN $num AS num", %{num: 5}, %{})
     end
 
     test "with parameters encoding a structure" do
@@ -111,7 +111,7 @@ defmodule Bolty.BoltProtocol.Message.MessageEncoderTest do
                116, 164, 137, 98, 111, 111, 107, 109, 97, 114, 107, 115, 144, 130, 100, 98, 192,
                132, 109, 111, 100, 101, 129, 119, 139, 116, 120, 95, 109, 101, 116, 97, 100, 97,
                116, 97, 192, 0, 0>> ==
-               RunMessage.encode(5.0, query, params, %{})
+               RunMessage.encode({5, 0}, query, params, %{})
     end
   end
 end

--- a/test/bolty/bolt_protocol/versions_test.exs
+++ b/test/bolty/bolt_protocol/versions_test.exs
@@ -4,19 +4,21 @@
 defmodule Bolty.BoltProtocol.VersionsTest do
   use ExUnit.Case, async: true
 
+  alias Bolty.BoltProtocol.Versions
+
   describe "available_versions/0" do
     @tag core: true
-    test "returns a list of available versions" do
-      assert Bolty.BoltProtocol.Versions.available_versions() == [
-               5.0,
-               5.1,
-               5.2,
-               5.3,
-               5.4,
-               5.6,
-               5.7,
-               5.8,
-               6.0
+    test "returns a list of {major, minor} versions" do
+      assert Versions.available_versions() == [
+               {5, 0},
+               {5, 1},
+               {5, 2},
+               {5, 3},
+               {5, 4},
+               {5, 6},
+               {5, 7},
+               {5, 8},
+               {6, 0}
              ]
     end
   end
@@ -24,7 +26,7 @@ defmodule Bolty.BoltProtocol.VersionsTest do
   describe "latest versions" do
     @tag core: true
     test "latest_versions/1" do
-      assert Bolty.BoltProtocol.Versions.latest_versions() == [
+      assert Versions.latest_versions() == [
                {6, 0},
                {5, 6..8},
                {5, 0..4},
@@ -33,26 +35,46 @@ defmodule Bolty.BoltProtocol.VersionsTest do
     end
   end
 
+  describe "parse/1" do
+    @tag core: true
+    test "parses the string form, not deprecated" do
+      assert Versions.parse("5.4") == {{5, 4}, false}
+      # A string distinguishes 5.10 from 5.1 (a float cannot).
+      assert Versions.parse("5.10") == {{5, 10}, false}
+    end
+
+    @tag core: true
+    test "accepts an explicit {major, minor} / {major, range} tuple, not deprecated" do
+      assert Versions.parse({5, 4}) == {{5, 4}, false}
+      assert Versions.parse({5, 0..4}) == {{5, 0..4}, false}
+    end
+
+    @tag core: true
+    test "accepts a float or bare integer but flags it deprecated" do
+      assert Versions.parse(5.4) == {{5, 4}, true}
+      assert Versions.parse(5) == {{5, 0}, true}
+    end
+  end
+
+  describe "format/1" do
+    @tag core: true
+    test "renders a {major, minor} version as a string" do
+      assert Versions.format({5, 8}) == "5.8"
+      assert Versions.format({5, 10}) == "5.10"
+    end
+  end
+
   describe "to_bytes/1" do
     @tag core: true
-    test "converts a float version to bytes version" do
-      assert Bolty.BoltProtocol.Versions.to_bytes(5.3) == <<0, 0, 3, 5>>
-    end
-
-    @tag core: true
-    test "converts an integer version to bytes version" do
-      assert Bolty.BoltProtocol.Versions.to_bytes(5) == <<0, 0, 0, 5>>
-    end
-
-    @tag core: true
     test "converts a {major, minor} version to bytes" do
-      assert Bolty.BoltProtocol.Versions.to_bytes({4, 3}) == <<0, 0, 3, 4>>
+      assert Versions.to_bytes({5, 3}) == <<0, 0, 3, 5>>
+      assert Versions.to_bytes({4, 3}) == <<0, 0, 3, 4>>
     end
 
     @tag core: true
     test "converts a {major, range} version to bytes" do
-      assert Bolty.BoltProtocol.Versions.to_bytes({5, 0..4}) == <<0, 4, 4, 5>>
-      assert Bolty.BoltProtocol.Versions.to_bytes({4, 1..3}) == <<0, 2, 3, 4>>
+      assert Versions.to_bytes({5, 0..4}) == <<0, 4, 4, 5>>
+      assert Versions.to_bytes({4, 1..3}) == <<0, 2, 3, 4>>
     end
   end
 end

--- a/test/bolty/client_test.exs
+++ b/test/bolty/client_test.exs
@@ -22,7 +22,7 @@ defmodule Bolty.ClientTest do
 
   defp handle_handshake(client, opts) do
     case client.bolt_version do
-      version when version >= 5.1 ->
+      version when version >= {5, 1} ->
         metadata = Client.send_hello(client, opts)
         Client.send_logon(client, opts)
         metadata
@@ -245,44 +245,36 @@ defmodule Bolty.ClientTest do
   describe "connect" do
     @tag :bolt_version_5_3
     test "multiple versions specified" do
-      opts = [versions: [5.3, 4, 3]] ++ @opts
+      opts = [versions: ["5.3", "4.0", "3.0"]] ++ @opts
       assert {:ok, client} = Client.connect(opts)
-      assert 5.3 == client.bolt_version
+      assert {5, 3} == client.bolt_version
     end
 
     @tag :bolt_version_5_3
     test "unordered versions specified" do
-      opts = [versions: [4, 3, 5.3]] ++ @opts
+      opts = [versions: ["4.0", "3.0", "5.3"]] ++ @opts
       assert {:ok, client} = Client.connect(opts)
-      assert 5.3 == client.bolt_version
+      assert {5, 3} == client.bolt_version
     end
 
     @tag :last_version
     test "no versions specified" do
       opts = [] ++ @opts
       assert {:ok, client} = Client.connect(opts)
-      # latest_versions/0 returns ranged tuples like `{5, 0..4}`; the
-      # negotiated `client.bolt_version` is the latest float in that range.
-      {major, minor_or_range} = hd(Versions.latest_versions())
-
-      minor =
-        case minor_or_range do
-          %Range{} = r -> List.last(Range.to_list(r))
-          m when is_integer(m) -> m
-        end
-
-      assert major + minor / 10 == client.bolt_version
+      # With no `:versions`, the highest mutually-supported version is negotiated;
+      # on the last_version job that is the newest version bolty supports.
+      assert client.bolt_version == List.last(Versions.available_versions())
     end
 
     @tag core: true
     test "zero version" do
-      opts = [versions: [0]] ++ @opts
+      opts = [versions: ["0.0"]] ++ @opts
       {:error, %Bolty.Error{code: :version_negotiation_error}} = Client.connect(opts)
     end
 
     @tag core: true
     test "major version incompatible with the server" do
-      opts = [versions: [50]] ++ @opts
+      opts = [versions: ["50.0"]] ++ @opts
       {:error, %Bolty.Error{code: :version_negotiation_error}} = Client.connect(opts)
     end
 

--- a/test/bolty/client_test.exs
+++ b/test/bolty/client_test.exs
@@ -106,6 +106,31 @@ defmodule Bolty.ClientTest do
       refute inspect(config) =~ "s3cret"
     end
 
+    test "parses string :versions to canonical tuples without warning" do
+      import ExUnit.CaptureLog
+
+      log =
+        capture_log(fn ->
+          {:ok, config} = Client.Config.new(auth: [username: "u"], versions: ["5.4", "6.0"])
+          # canonical tuples, sorted desc, padded to the 4 handshake slots
+          assert config.versions == [{6, 0}, {5, 4}, {0, 0}, {0, 0}]
+        end)
+
+      refute log =~ "deprecated"
+    end
+
+    test "accepts float :versions but logs a one-time deprecation warning" do
+      import ExUnit.CaptureLog
+
+      log =
+        capture_log(fn ->
+          {:ok, config} = Client.Config.new(auth: [username: "u"], versions: [5.4])
+          assert config.versions == [{5, 4}, {0, 0}, {0, 0}, {0, 0}]
+        end)
+
+      assert log =~ "deprecated"
+    end
+
     test "maps schemes to the correct TLS verification intent" do
       base_opts = [
         auth: [username: "usertests"]
@@ -284,7 +309,7 @@ defmodule Bolty.ClientTest do
           101, 109, 101, 116, 114, 121, 46, 101, 110, 97, 98, 108, 101, 100, 194, 0, 0>>
 
       pid = Bolty.Mocks.SockMock.start_link(framed(body(chunk)))
-      client = %{sock: {Bolty.Mocks.SockMock, pid}, bolt_version: 1.0}
+      client = %{sock: {Bolty.Mocks.SockMock, pid}, bolt_version: {1, 0}}
       {:ok, message} = Client.recv_packets(client, fn _bolt_version, data -> {:ok, data} end, 0)
 
       assert message == [
@@ -314,7 +339,7 @@ defmodule Bolty.ClientTest do
 
       pid = Bolty.Mocks.SockMock.start_link(framed(body(chunk1)) ++ framed(body(chunk2)))
 
-      client = %{sock: {Bolty.Mocks.SockMock, pid}, bolt_version: 3.0}
+      client = %{sock: {Bolty.Mocks.SockMock, pid}, bolt_version: {3, 0}}
       {:ok, message} = Client.recv_packets(client, fn _bolt_version, data -> {:ok, data} end, 0)
 
       assert message == [
@@ -348,7 +373,7 @@ defmodule Bolty.ClientTest do
           [@noop_chunk] ++ framed(body(chunk1)) ++ [@noop_chunk] ++ framed(body(chunk2))
         )
 
-      client = %{sock: {Bolty.Mocks.SockMock, pid}, bolt_version: 5.0}
+      client = %{sock: {Bolty.Mocks.SockMock, pid}, bolt_version: {5, 0}}
       {:ok, message} = Client.recv_packets(client, fn _bolt_version, data -> {:ok, data} end, 0)
 
       assert message == [
@@ -380,7 +405,7 @@ defmodule Bolty.ClientTest do
           framed(success)
 
       pid = Bolty.Mocks.SockMock.start_link(frames)
-      client = %{sock: {Bolty.Mocks.SockMock, pid}, bolt_version: 5.0}
+      client = %{sock: {Bolty.Mocks.SockMock, pid}, bolt_version: {5, 0}}
       {:ok, message} = Client.recv_packets(client, fn _bolt_version, data -> {:ok, data} end, 0)
 
       assert message == [{:success, %{}}, {:record, [1024, 2048]}]

--- a/test/bolty/connection_reset_rescue_test.exs
+++ b/test/bolty/connection_reset_rescue_test.exs
@@ -41,8 +41,8 @@ defmodule Bolty.ConnectionResetRescueTest do
 
     client = %Bolty.Client{
       sock: {ScriptedSock, agent},
-      bolt_version: 5.0,
-      policy: Bolty.Policy.Resolver.resolve(5.0, %{})
+      bolt_version: {5, 0},
+      policy: Bolty.Policy.Resolver.resolve({5, 0}, %{})
     }
 
     state = %Bolty.Connection{client: client, in_transaction: false}

--- a/test/bolty/connection_test.exs
+++ b/test/bolty/connection_test.exs
@@ -24,7 +24,7 @@ defmodule Bolty.ConnectionTest do
 
     assert is_bitstring(server_version)
     assert is_bitstring(connection_id)
-    assert is_float(client.bolt_version)
+    assert is_tuple(client.bolt_version)
     assert :ok = Connection.disconnect(:stop, conn_data)
   end
 
@@ -45,7 +45,7 @@ defmodule Bolty.ConnectionTest do
 
     assert is_bitstring(server_version)
     assert is_bitstring(connection_id)
-    assert is_float(client.bolt_version)
+    assert is_tuple(client.bolt_version)
 
     assert {:ok, %Connection{client: _} = conn_data} =
              Connection.checkout(conn_data)
@@ -72,7 +72,7 @@ defmodule Bolty.ConnectionTest do
       Connection.connect(@opts)
 
     assert String.starts_with?(server_version, "Neo4j/")
-    assert client.bolt_version == 5.0
+    assert client.bolt_version == {5, 0}
     assert is_bitstring(connection_id)
     assert String.contains?(connection_id, "bolt-")
 
@@ -87,7 +87,7 @@ defmodule Bolty.ConnectionTest do
       Connection.connect(@opts)
 
     assert String.starts_with?(server_version, "Neo4j/")
-    assert client.bolt_version == 5.1
+    assert client.bolt_version == {5, 1}
     assert is_bitstring(connection_id)
     assert String.contains?(connection_id, "bolt-")
 
@@ -102,7 +102,7 @@ defmodule Bolty.ConnectionTest do
       Connection.connect(@opts)
 
     assert String.starts_with?(server_version, "Neo4j/")
-    assert client.bolt_version == 5.2
+    assert client.bolt_version == {5, 2}
     assert is_bitstring(connection_id)
     assert String.contains?(connection_id, "bolt-")
 
@@ -117,7 +117,7 @@ defmodule Bolty.ConnectionTest do
       Connection.connect(@opts)
 
     assert String.starts_with?(server_version, "Neo4j/")
-    assert client.bolt_version == 5.3
+    assert client.bolt_version == {5, 3}
     assert is_bitstring(connection_id)
     assert String.contains?(connection_id, "bolt-")
 
@@ -132,7 +132,7 @@ defmodule Bolty.ConnectionTest do
       Connection.connect(@opts)
 
     assert String.starts_with?(server_version, "Neo4j/")
-    assert client.bolt_version == 5.4
+    assert client.bolt_version == {5, 4}
     assert is_bitstring(connection_id)
     assert String.contains?(connection_id, "bolt-")
 
@@ -147,7 +147,7 @@ defmodule Bolty.ConnectionTest do
       Connection.connect(@opts)
 
     assert String.starts_with?(server_version, "Neo4j/")
-    assert client.bolt_version == 5.6
+    assert client.bolt_version == {5, 6}
     assert is_bitstring(connection_id)
     assert String.contains?(connection_id, "bolt-")
 
@@ -162,7 +162,7 @@ defmodule Bolty.ConnectionTest do
       Connection.connect(@opts)
 
     assert String.starts_with?(server_version, "Neo4j/")
-    assert client.bolt_version == 5.7
+    assert client.bolt_version == {5, 7}
     assert is_bitstring(connection_id)
     assert String.contains?(connection_id, "bolt-")
 
@@ -177,7 +177,7 @@ defmodule Bolty.ConnectionTest do
       Connection.connect(@opts)
 
     assert String.starts_with?(server_version, "Neo4j/")
-    assert client.bolt_version == 5.8
+    assert client.bolt_version == {5, 8}
     assert is_bitstring(connection_id)
     assert String.contains?(connection_id, "bolt-")
 
@@ -210,7 +210,7 @@ defmodule Bolty.ConnectionTest do
       Bolty.transaction(pid, fn conn ->
         info = Bolty.connection_info(conn)
 
-        assert is_float(info.bolt_version)
+        assert is_binary(info.bolt_version)
         assert is_bitstring(info.server_version)
         assert %Bolty.Policy{} = info.policy
       end)

--- a/test/bolty/policy/resolver_test.exs
+++ b/test/bolty/policy/resolver_test.exs
@@ -11,19 +11,22 @@ defmodule Bolty.Policy.ResolverTest do
     @describetag :core
 
     test "Bolt 5.0 resolves to :evolved" do
-      assert %Policy{datetime: :evolved} = Resolver.resolve(5.0, %{"server" => "Neo4j/5.26.27"})
+      assert %Policy{datetime: :evolved} =
+               Resolver.resolve({5, 0}, %{"server" => "Neo4j/5.26.27"})
     end
 
     test "Bolt 5.4 resolves to :evolved" do
-      assert %Policy{datetime: :evolved} = Resolver.resolve(5.4, %{"server" => "Neo4j/5.26.27"})
+      assert %Policy{datetime: :evolved} =
+               Resolver.resolve({5, 4}, %{"server" => "Neo4j/5.26.27"})
     end
 
     test "Bolt 5.8 resolves to :evolved" do
-      assert %Policy{datetime: :evolved} = Resolver.resolve(5.8, %{"server" => "Neo4j/5.26.27"})
+      assert %Policy{datetime: :evolved} =
+               Resolver.resolve({5, 8}, %{"server" => "Neo4j/5.26.27"})
     end
 
     test "missing server metadata does not crash; still decides from bolt_version" do
-      assert %Policy{datetime: :evolved} = Resolver.resolve(5.0, %{})
+      assert %Policy{datetime: :evolved} = Resolver.resolve({5, 0}, %{})
     end
 
     test "nil bolt_version falls through to Policy defaults" do
@@ -37,22 +40,22 @@ defmodule Bolty.Policy.ResolverTest do
 
     test "Bolt 5.0 uses :notifications_disabled_categories" do
       assert %Policy{notifications_field: :notifications_disabled_categories} =
-               Resolver.resolve(5.0, %{})
+               Resolver.resolve({5, 0}, %{})
     end
 
     test "Bolt 5.4 uses :notifications_disabled_categories" do
       assert %Policy{notifications_field: :notifications_disabled_categories} =
-               Resolver.resolve(5.4, %{})
+               Resolver.resolve({5, 4}, %{})
     end
 
     test "Bolt 5.6 uses :notifications_disabled_classifications" do
       assert %Policy{notifications_field: :notifications_disabled_classifications} =
-               Resolver.resolve(5.6, %{})
+               Resolver.resolve({5, 6}, %{})
     end
 
     test "Bolt 5.8 uses :notifications_disabled_classifications" do
       assert %Policy{notifications_field: :notifications_disabled_classifications} =
-               Resolver.resolve(5.8, %{})
+               Resolver.resolve({5, 8}, %{})
     end
   end
 
@@ -60,19 +63,19 @@ defmodule Bolty.Policy.ResolverTest do
     @describetag :core
 
     test "Bolt 5.0 has gql_errors: false" do
-      assert %Policy{gql_errors: false} = Resolver.resolve(5.0, %{})
+      assert %Policy{gql_errors: false} = Resolver.resolve({5, 0}, %{})
     end
 
     test "Bolt 5.6 has gql_errors: false" do
-      assert %Policy{gql_errors: false} = Resolver.resolve(5.6, %{})
+      assert %Policy{gql_errors: false} = Resolver.resolve({5, 6}, %{})
     end
 
     test "Bolt 5.7 has gql_errors: true" do
-      assert %Policy{gql_errors: true} = Resolver.resolve(5.7, %{})
+      assert %Policy{gql_errors: true} = Resolver.resolve({5, 7}, %{})
     end
 
     test "Bolt 5.8 has gql_errors: true" do
-      assert %Policy{gql_errors: true} = Resolver.resolve(5.8, %{})
+      assert %Policy{gql_errors: true} = Resolver.resolve({5, 8}, %{})
     end
   end
 
@@ -80,11 +83,11 @@ defmodule Bolty.Policy.ResolverTest do
     @describetag :core
 
     test "Bolt 5.8 has vectors: false" do
-      assert %Policy{vectors: false} = Resolver.resolve(5.8, %{})
+      assert %Policy{vectors: false} = Resolver.resolve({5, 8}, %{})
     end
 
     test "Bolt 6.0 has vectors: true" do
-      assert %Policy{vectors: true} = Resolver.resolve(6.0, %{})
+      assert %Policy{vectors: true} = Resolver.resolve({6, 0}, %{})
     end
   end
 
@@ -92,11 +95,11 @@ defmodule Bolty.Policy.ResolverTest do
     @describetag :core
 
     test "Bolt 5.0 has cypher_5: true" do
-      assert %Policy{cypher_5: true} = Resolver.resolve(5.0, %{"server" => "Neo4j/5.26.27"})
+      assert %Policy{cypher_5: true} = Resolver.resolve({5, 0}, %{"server" => "Neo4j/5.26.27"})
     end
 
     test "Bolt 6.0 has cypher_5: true" do
-      assert %Policy{cypher_5: true} = Resolver.resolve(6.0, %{"server" => "Neo4j/2026.05.0"})
+      assert %Policy{cypher_5: true} = Resolver.resolve({6, 0}, %{"server" => "Neo4j/2026.05.0"})
     end
 
     test "nil bolt_version falls through to cypher_5: false" do
@@ -108,19 +111,20 @@ defmodule Bolty.Policy.ResolverTest do
     @describetag :core
 
     test "calendar server >= 2025.06 has cypher_25: true" do
-      assert %Policy{cypher_25: true} = Resolver.resolve(5.8, %{"server" => "Neo4j/2025.06.0"})
+      assert %Policy{cypher_25: true} = Resolver.resolve({5, 8}, %{"server" => "Neo4j/2025.06.0"})
     end
 
     test "calendar server < 2025.06 has cypher_25: false" do
-      assert %Policy{cypher_25: false} = Resolver.resolve(5.8, %{"server" => "Neo4j/2025.05.0"})
+      assert %Policy{cypher_25: false} =
+               Resolver.resolve({5, 8}, %{"server" => "Neo4j/2025.05.0"})
     end
 
     test "semver 5.26.x server has cypher_25: false" do
-      assert %Policy{cypher_25: false} = Resolver.resolve(5.8, %{"server" => "Neo4j/5.26.27"})
+      assert %Policy{cypher_25: false} = Resolver.resolve({5, 8}, %{"server" => "Neo4j/5.26.27"})
     end
 
     test "missing server metadata has cypher_25: false" do
-      assert %Policy{cypher_25: false} = Resolver.resolve(5.8, %{})
+      assert %Policy{cypher_25: false} = Resolver.resolve({5, 8}, %{})
     end
   end
 
@@ -129,25 +133,26 @@ defmodule Bolty.Policy.ResolverTest do
 
     test "semver 5.26.x server has dynamic_labels: true, cypher_25: false" do
       assert %Policy{dynamic_labels: true, cypher_25: false} =
-               Resolver.resolve(5.8, %{"server" => "Neo4j/5.26.27"})
+               Resolver.resolve({5, 8}, %{"server" => "Neo4j/5.26.27"})
     end
 
     test "calendar server >= 2025.06 has dynamic_labels and cypher_25: true" do
       assert %Policy{dynamic_labels: true, cypher_25: true} =
-               Resolver.resolve(5.8, %{"server" => "Neo4j/2025.06.0"})
+               Resolver.resolve({5, 8}, %{"server" => "Neo4j/2025.06.0"})
     end
 
     test "calendar server < 2025.06 still has dynamic_labels: true, cypher_25: false" do
       assert %Policy{dynamic_labels: true, cypher_25: false} =
-               Resolver.resolve(5.8, %{"server" => "Neo4j/2025.05.0"})
+               Resolver.resolve({5, 8}, %{"server" => "Neo4j/2025.05.0"})
     end
 
     test "pre-5.26 semver server has dynamic_labels: false" do
-      assert %Policy{dynamic_labels: false} = Resolver.resolve(5.8, %{"server" => "Neo4j/5.25.1"})
+      assert %Policy{dynamic_labels: false} =
+               Resolver.resolve({5, 8}, %{"server" => "Neo4j/5.25.1"})
     end
 
     test "missing server metadata has dynamic_labels: false" do
-      assert %Policy{dynamic_labels: false} = Resolver.resolve(5.8, %{})
+      assert %Policy{dynamic_labels: false} = Resolver.resolve({5, 8}, %{})
     end
   end
 end

--- a/test/bolty/telemetry_test.exs
+++ b/test/bolty/telemetry_test.exs
@@ -89,7 +89,7 @@ defmodule Bolty.TelemetryTest do
 
       assert_receive {:telemetry, [:bolty, :connect], connect_meas, connect_meta}
       assert is_integer(connect_meas.duration)
-      assert is_float(connect_meta.bolt_version)
+      assert is_binary(connect_meta.bolt_version)
       assert is_bitstring(connect_meta.server_version)
       assert is_bitstring(connect_meta.connection_id)
 

--- a/test/bolty/timeout_test.exs
+++ b/test/bolty/timeout_test.exs
@@ -30,9 +30,9 @@ defmodule Bolty.TimeoutTest do
   defp client(agent, recv_timeout) do
     %Client{
       sock: {TimingOutSock, agent},
-      bolt_version: 5.0,
+      bolt_version: {5, 0},
       recv_timeout: recv_timeout,
-      policy: Bolty.Policy.Resolver.resolve(5.0, %{})
+      policy: Bolty.Policy.Resolver.resolve({5, 0}, %{})
     }
   end
 

--- a/test/bolty/tls_test.exs
+++ b/test/bolty/tls_test.exs
@@ -37,7 +37,7 @@ defmodule Bolty.TLSTest do
       opts = [scheme: "bolt+s", ssl_opts: [cacertfile: @ca_path]] ++ base_opts()
 
       assert {:ok, client} = Client.connect(opts)
-      assert is_float(client.bolt_version)
+      assert is_tuple(client.bolt_version)
     end
 
     test "fails against the OS trust store (server CA is unknown)" do
@@ -70,7 +70,7 @@ defmodule Bolty.TLSTest do
       opts = [scheme: "bolt+ssc"] ++ base_opts()
 
       assert {:ok, client} = Client.connect(opts)
-      assert is_float(client.bolt_version)
+      assert is_tuple(client.bolt_version)
     end
   end
 end

--- a/test/mix/tasks/test_matrix_test.exs
+++ b/test/mix/tasks/test_matrix_test.exs
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Mix.Tasks.Test.MatrixTest do
+  @moduledoc """
+  Shadow test for the `mix test.matrix` per-version mapping. The task shells out
+  to `mix test` (not exercised here), but the pure version -> {string, port}
+  decision is testable in isolation — and regression-proofs it against changes
+  to the internal version representation (which once broke the task silently).
+  """
+  use ExUnit.Case, async: true
+
+  alias Mix.Tasks.Test.Matrix
+
+  describe "version_env/3" do
+    test "5.x versions use the default port and format as strings" do
+      assert Matrix.version_env({5, 0}, "7687", "7689") == {"5.0", "7687"}
+      assert Matrix.version_env({5, 8}, "7687", "7689") == {"5.8", "7687"}
+    end
+
+    test "6.x+ versions use the Bolt 6 port" do
+      assert Matrix.version_env({6, 0}, "7687", "7689") == {"6.0", "7689"}
+      assert Matrix.version_env({7, 2}, "7687", "7689") == {"7.2", "7689"}
+    end
+
+    test "renders the version as a string (a float would drop 5.10 -> 5.1)" do
+      assert {"5.10", _} = Matrix.version_env({5, 10}, "7687", "7689")
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,15 +1,17 @@
 # SPDX-FileCopyrightText: 2024 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
-alias Bolty.Utils.Converters
+alias Bolty.BoltProtocol.Versions
 
 Logger.configure(level: :debug)
 
+# Bolt versions are `{major, minor}` tuples internally; parse BOLT_VERSIONS
+# ("5.4,6.0") into that form so the tags below line up with available_versions/0.
 env_versions =
   System.get_env("BOLT_VERSIONS", "")
   |> String.split(",")
   |> Enum.reject(&(&1 == ""))
-  |> Enum.map(&Converters.to_float/1)
+  |> Enum.map(fn v -> Versions.parse(v) |> elem(0) end)
 
 # Is a Neo4j server configured for this run? CI, `mix test.matrix`, and local
 # `BOLT_TCP_PORT=7687 mix test` all set one of these. When none is set (a plain
@@ -44,13 +46,12 @@ available_versions = Bolty.BoltProtocol.Versions.available_versions()
 
 {include, exclude} =
   Enum.reduce(available_versions, {include, exclude}, fn version, {inc, exc} ->
-    [major | [minor]] =
-      version |> Float.to_string() |> String.split(".") |> Enum.map(&String.to_integer/1)
+    {major, minor} = version
 
     bolt_version_atom =
       String.to_atom("bolt_version_#{Integer.to_string(major)}_#{Integer.to_string(minor)}")
 
-    bolt_version_x = String.to_atom("bolt_#{Integer.to_string(trunc(version))}_x")
+    bolt_version_x = String.to_atom("bolt_#{Integer.to_string(major)}_x")
 
     if version in env_versions do
       case version === List.last(available_versions) do
@@ -115,9 +116,11 @@ defmodule Bolty.TestHelper do
   end
 
   defp maybe_put_env_versions(opts) do
+    # Pass the raw string forms ("5.4") — the driver's :versions option now takes
+    # strings; floats are deprecated and would log a warning on every run.
     case System.get_env("BOLT_VERSIONS", "") |> String.split(",") |> Enum.reject(&(&1 == "")) do
       [] -> opts
-      versions -> Keyword.put(opts, :versions, Enum.map(versions, &Converters.to_float/1))
+      versions -> Keyword.put(opts, :versions, versions)
     end
   end
 

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -90,7 +90,7 @@ Canonical option names (what `Bolty.Client.Config.new/1` actually reads):
 | `:port` | Port | `7687` |
 | `:scheme` | One of the schemes below | `"bolt+s"` |
 | `:auth` | `[username: ..., password: ...]` (`:username` required) | required |
-| `:versions` | Bolt versions to negotiate. Accepts floats (`[5.4]`) or range tuples (`[{5, 6..8}, {5, 0..4}]`). Range tuples are preferred — the handshake has only 4 slots and ranges cover more versions per slot. Omit to use `Versions.latest_versions()` (all supported versions, auto-rangeified). | `Versions.latest_versions()` |
+| `:versions` | Bolt versions to negotiate. Accepts strings (`["5.4"]`) or range tuples (`[{5, 6..8}, {5, 0..4}]`); floats (`[5.4]`) are deprecated (can't distinguish `5.10` from `5.1`) but still accepted with a warning. Range tuples are preferred — the handshake has only 4 slots and ranges cover more per slot. Omit to use `Versions.latest_versions()`. `connection_info/1` reports the negotiated `bolt_version` as a string (`"5.8"`). | `Versions.latest_versions()` |
 | `:user_agent` | Client identity string | `"bolty/<version>"` |
 | `:notifications_minimum_severity` | Bolt 5.2+ | `nil` |
 | `:notifications_disabled_categories` | Bolt 5.2–5.5 | `nil` |


### PR DESCRIPTION
Closes #95. Split out of #77 and done first — it fixes the public types #77 will `@spec`.

## Problem
`bolt_version` was a `float()`. A float can't distinguish `5.10` from `5.1`, and it misdecodes on the wire — `5.10` would round to `6.0`. Wrong representation for a version, and a latent bug the moment Neo4j ships a minor ≥ 10.

## Change
**Internal: `{major, minor}` integer tuples.** Tuple term-ordering compares as versions (`{5, 10} > {5, 6}`), so every version guard converts cleanly (`is_float(v) and v >= 5.1` → `is_tuple(v) and v >= {5, 1}`) across the 11 message encoders, `Policy.Resolver`, and `do_init`. Floats never flow past the input boundary.

**Public: strings.**
- `connection_info/1` reports `bolt_version` as a string (`"5.8"`) — a **clean swap** (no dual key). The ash_neo4j coupling audit confirms it doesn't consume `bolt_version`, so this is low-risk.
- The `:versions` option accepts strings (`["5.4"]`) and `{major, minor..minor}` range tuples; **floats are deprecated** — still accepted, with a one-time `Logger.warning`.

**`Versions` module** gains `parse/1` (string | float | tuple → canonical, flags deprecated floats) and `format/1` (`{major, minor}` → `"5.8"`); `decode_version`/`to_bytes`/`rangeify` work in tuples.

## Breaking
- `connection_info/1` `bolt_version` is now `String.t()` (`"5.8"`), was `float()` (`5.8`).
- Passing float `:versions` is deprecated (accepted, logs a warning). Use strings.

## Verification
- Bare unit **210 passed** (no DB), integration **302 passed** (real handshake → tuple decode → policy → `connection_info` string, across all Bolt versions).
- New coverage: `Versions.parse/format` unit tests (incl. the `5.10 ≠ 5.1` case), and Config tests asserting string `:versions` parse with no warning + float `:versions` logs the deprecation.
- End-to-end confirmed: `connection_info/1` returns `"5.4"`; float `:versions` logs the warning.
- `mix format`, `mix compile --warnings-as-errors`, `mix dialyzer` (0 errors), `reuse lint` all clean.

Docs updated: README (`connection_info/1` example + `:versions` examples), `usage-rules.md`, and the `:versions` / `connection_info/1` `@doc`s.