### PR TITLE
Declare public/internal API boundary + complete @specs (#77)

### DIFF
--- a/guides/public_api.md
+++ b/guides/public_api.md
@@ -1,0 +1,74 @@
+<!--
+SPDX-FileCopyrightText: 2024 bolty contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Public API & compatibility boundary
+
+This page states what bolty considers **public** — the surface covered by
+semantic versioning — versus what is **internal** and may change in any release.
+If you depend on something not listed here as public, treat it as liable to
+change without a major-version bump.
+
+## Public API
+
+These modules and their documented functions are the supported surface:
+
+- **`Bolty`** — the entrypoint: `start_link/1`, `child_spec/1`, `query/4`,
+  `query!/4`, `query_many/4`, `query_many!/4`, `transaction/4`, `rollback/2`,
+  and `connection_info/1`.
+- **`Bolty.Response`** — the result struct returned by `query/4`
+  (`results`, `fields`, `records`, `plan`, `notifications`, `stats`, `profile`,
+  `type`, `bookmark`). It implements `Enumerable` (iterating **rows**), and
+  `Bolty.Response.first/1` returns the first row.
+- **`Bolty.Error`** — the error struct. Its `:bolt` field is a
+  `%{code: ..., message: ...}` map; match on that for server error details.
+- **`Bolty.Policy`** — the resolved per-connection capability struct, read via
+  `connection_info/1`.
+- **`Bolty.Types.*`** — the value types decoded from / encoded to Neo4j:
+  `Node`, `Relationship`, `UnboundRelationship`, `Path`, `TimeWithTZOffset`,
+  `DateTimeWithTZOffset`, `Vector`, `Point` (plus standard Elixir `Time`,
+  `NaiveDateTime`, `Duration`).
+- **`Bolty.ResponseEncoder`** and **`Bolty.ResponseEncoder.Json`**
+  (with the `Jason`/`Poison` back-ends) — JSON encoding of responses.
+- **`Bolty.PackStream.Packer`** — you may `@derive` it on your own structs to
+  control how they serialize into query parameters, e.g.
+  `@derive [{Bolty.PackStream.Packer, fields: [:name]}]`.
+
+## Internal
+
+Everything marked `@moduledoc false` is internal and unsupported for direct
+use. That includes:
+
+```text
+Bolty.Client               Bolty.Connection
+Bolty.BoltProtocol.*       Bolty.BoltProtocol.Versions
+Bolty.Policy.Resolver      Bolty.ConnectionInfo
+Bolty.PackStream           (unpacker, markers)
+Bolty.Query                Bolty.Queries
+Bolty.Utils.*
+```
+
+Construct queries through `Bolty.query/4` and `Bolty.query_many/4` rather than
+building those structs directly.
+
+## The `connection_info/1` contract
+
+`Bolty.connection_info/1` returns a map with:
+
+- `:bolt_version` — the negotiated Bolt version as a string (e.g. `"5.8"`)
+- `:server_version` — the server product string (e.g. `"Neo4j/5.26.27"`)
+- `:policy` — the resolved `%Bolty.Policy{}`
+
+## Consumer compatibility contract
+
+These shapes are load-bearing for downstream consumers (notably
+[`ash_neo4j`](https://github.com/diffo-dev/ash_neo4j)) and will not change
+without a major-version bump:
+
+- `%Bolty.Response{}` keeps its `results` field.
+- `%Bolty.Types.Vector{}` keeps its `data` field.
+- `%Bolty.Error{}` keeps `:bolt` as a `%{code, message}` map.
+- `connection_info/1` keeps its `:policy` and `:server_version` keys.
+- `%Bolty.Policy{}` keeps its `cypher_25` and `dynamic_labels` fields (new
+  fields may be added).

--- a/lib/bolty.ex
+++ b/lib/bolty.ex
@@ -140,6 +140,8 @@ defmodule Bolty do
   {:ok, people} = Bolty.query(conn, "MATCH (n:PERSON) RETURN n", %{}, [db: "mydb"])
   ```
   """
+  @spec query(conn(), String.t(), map(), keyword()) ::
+          {:ok, Bolty.Response.t()} | {:error, Bolty.Error.t() | DBConnection.ConnectionError.t()}
   def query(conn, statement, params \\ %{}, opts \\ []) do
     formatted_params = Map.new(params)
 
@@ -165,6 +167,7 @@ defmodule Bolty do
   people = Bolty.query!(conn, "MATCH (n:PERSON) RETURN n", %{}, [db: "mydb"])
   ```
   """
+  @spec query!(conn(), String.t(), map(), keyword()) :: Bolty.Response.t()
   def query!(conn, statement, params \\ %{}, opts \\ []) do
     case query(conn, statement, params, opts) do
       {:ok, result} -> result
@@ -185,6 +188,9 @@ defmodule Bolty do
   runs one bare statement at a time), and blank or comment-only segments are
   skipped rather than sent to the server.
   """
+  @spec query_many(conn(), String.t(), map(), keyword()) ::
+          {:ok, [Bolty.Response.t()]}
+          | {:error, Bolty.Error.t() | DBConnection.ConnectionError.t()}
   def query_many(conn, statement, params \\ %{}, opts \\ []) do
     formatted_params = Map.new(params)
 
@@ -192,6 +198,7 @@ defmodule Bolty do
     do_query(conn, queries, formatted_params, opts)
   end
 
+  @spec query_many!(conn(), String.t(), map(), keyword()) :: [Bolty.Response.t()]
   def query_many!(conn, statement, params \\ %{}, opts \\ []) do
     case query_many(conn, statement, params, opts) do
       {:ok, result} -> result

--- a/lib/bolty/bolt_protocol/versions.ex
+++ b/lib/bolty/bolt_protocol/versions.ex
@@ -24,10 +24,12 @@ defmodule Bolty.BoltProtocol.Versions do
   @type version :: {non_neg_integer(), non_neg_integer()}
   @type version_range :: {non_neg_integer(), Range.t()}
 
+  @spec available_versions() :: [version()]
   def available_versions() do
     @available_bolt_versions
   end
 
+  @spec latest_versions() :: [version() | version_range()]
   def latest_versions() do
     ((available_versions() |> Enum.sort(&>=/2) |> rangeify()) ++ [{0, 0}, {0, 0}, {0, 0}])
     |> Enum.take(4)
@@ -65,6 +67,7 @@ defmodule Bolty.BoltProtocol.Versions do
   @spec format(version()) :: String.t()
   def format({major, minor}), do: "#{major}.#{minor}"
 
+  @spec to_bytes(version() | version_range()) :: binary()
   def to_bytes({major, minor}) when is_integer(minor) do
     <<0, 0>> <> <<minor, major>>
   end
@@ -75,6 +78,7 @@ defmodule Bolty.BoltProtocol.Versions do
     <<0>> <> <<previous, minor, major>>
   end
 
+  @spec rangeify([version()]) :: [version() | version_range()]
   def rangeify(list) when is_list(list) do
     list
     |> Enum.reduce([], fn {major, minor} = value, acc ->

--- a/lib/bolty/query.ex
+++ b/lib/bolty/query.ex
@@ -2,12 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.Query do
-  @moduledoc """
-  This module defines a structure to represent Bolty single query.
-
-  A Bolty query consists of a statement and additional data (extra).
-
-  """
+  @moduledoc false
+  # Internal: the struct wrapping a single statement + `extra` options, built by
+  # `Bolty.query/4` and passed through the `DBConnection.Query` protocol. Not
+  # part of the public API — construct queries via `Bolty.query/4`.
 
   @typedoc """
   Extra contains additional options. _Introduced in bolt 3_
@@ -39,11 +37,9 @@ defmodule Bolty.Query do
 end
 
 defmodule Bolty.Queries do
-  @moduledoc """
-  This module defines a structure to represent Bolty queries.
-
-  It consists of a statement and additional data (extra). The extra configuration applies to all queries.
-  """
+  @moduledoc false
+  # Internal: the struct wrapping a `;`-separated batch + shared `extra`, built
+  # by `Bolty.query_many/4`. Not part of the public API — use `query_many/4`.
 
   @type t :: %__MODULE__{
           statement: String.t(),

--- a/lib/bolty/query.ex
+++ b/lib/bolty/query.ex
@@ -24,11 +24,12 @@ defmodule Bolty.Query do
 
   * `:tx_metadata` - is a map that can contain some metadata information, mainly used for logging. (default: `null`)
   """
-  @type extra() ::
-          {:bookmarks, list(String.t()) | nil}
-          | {:mode, String.t() | nil}
-          | {:db, String.t() | nil}
-          | {:tx_metadata, String.t() | nil}
+  @type extra() :: %{
+          optional(:bookmarks) => [String.t()],
+          optional(:mode) => String.t(),
+          optional(:db) => String.t() | nil,
+          optional(:tx_metadata) => map()
+        }
   @type t :: %__MODULE__{
           statement: String.t(),
           extra: extra()

--- a/lib/bolty/response.ex
+++ b/lib/bolty/response.ex
@@ -49,6 +49,7 @@ defmodule Bolty.Response do
             type: nil,
             bookmark: nil
 
+  @spec new(tuple()) :: t()
   def new(
         statement_result(
           result_run: result_run,
@@ -70,6 +71,7 @@ defmodule Bolty.Response do
     }
   end
 
+  @spec first(t()) :: map() | nil
   def first(%__MODULE__{results: []}), do: nil
   def first(%__MODULE__{results: [head | _tail]}), do: head
 

--- a/mix.exs
+++ b/mix.exs
@@ -106,7 +106,7 @@ defmodule Bolty.Mixfile do
       source_ref: "v#{@version}",
       source_url: @url_github,
       main: "readme",
-      extras: ["README.md", "guides/telemetry.md", "CHANGELOG.md"]
+      extras: ["README.md", "guides/public_api.md", "guides/telemetry.md", "CHANGELOG.md"]
     ]
   end
 


### PR DESCRIPTION
Closes #77. Also ticks the `@spec query*` + `Query.extra` box on #80.

Five workstreams, one commit each (the dialyzer gate already exists in CI, so it's a verification step, not a commit).

## A — `fix: type Query/Queries extra as the map it actually is`
`@type extra()` declared a single keyword *tuple* but the struct default is `%{}` and the runtime value is a map (`Enum.into(%{})` in `query/4`). Wrong on both axes, and `:tx_metadata` was typed `String.t()` when it's a map. Redefined as a map with optional keys, matching the existing `Bolty.option` type. Not a public-contract change — verified `ash_neo4j` never constructs `Query`/`Queries` or reads `.extra`.

## B2 — `feat: spec the internal version surface for dialyzer`
Added `@spec`s to the remaining `Bolty.BoltProtocol.Versions` functions (`available_versions/0`, `latest_versions/0`, `to_bytes/1`, `rangeify/1`). `@moduledoc false` doesn't exempt a module from dialyzer — this is the representation-carrying surface where the #95-class regression (`Float.to_string`/`trunc` on a `{major, minor}` tuple) hides. `parse/1`, `format/1`, `Policy.Resolver.resolve/2` were already specced.

## B1 — `feat: @spec the public API surface`
Specced the four primary entrypoints — `query/4`, `query!/4`, `query_many/4`, `query_many!/4` — with real return shapes (`{:ok, Response.t()}` / `{:ok, [Response.t()]}`, errors as `Bolty.Error.t() | DBConnection.ConnectionError.t()`), plus `Response.new/1` and `first/1`. `Types.*` and `ResponseEncoder` were already specced.

## C — `docs: declare the public/internal API boundary`
- New `guides/public_api.md` (in the ex_doc extras): the supported surface, the `@moduledoc false` internals, the `connection_info/1` contract, and the downstream compatibility contract — the struct shapes (`%Response{results}`, `%Types.Vector{data}`, `%Error{}.bolt`, `connection_info/1` `:policy`/`:server_version`, `%Policy{}` `cypher_25`/`dynamic_labels`) that won't change without a major bump.
- Marked `Bolty.Query` / `Bolty.Queries` `@moduledoc false` (internal plumbing).
- `Bolty.PackStream.Packer` kept **public** — its `@derive` lets consumers control how their own structs serialize into query params.

## Not in scope
The issue's `bolt_version` float→string bullet was already resolved by #95; this PR only specs that settled surface.

## Verification
- `mix compile --force --warnings-as-errors` clean, `mix format --check-formatted` clean.
- **`mix dialyzer`: 0 errors** (the whole point — the new specs feed the PLT).
- `mix docs` builds with no warnings (guide links resolve; internals aren't autolinked).
- Full suite against local Neo4j (5.26.28, Bolt 5.4): **344 tests, 3 properties**.