### PR TITLE
Docs & packaging polish + the mix credo gate (#78)

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -47,7 +47,12 @@
         # Priority values are: `low, normal, high, higher`
         {Credo.Check.Design.AliasUsage, priority: :low},
         # For others you can set parameters
-        {Credo.Check.Design.DuplicatedCode, mass_threshold: 16, nodes_threshold: 2},
+        # mass_threshold 30 (up from the stricter 16): the one-module-per-Bolt-
+        # message design leaves small, deliberately-parallel `encode/_` clauses
+        # (e.g. COMMIT/ROLLBACK, RESET/GOODBYE) that differ only by signature and
+        # name. Keeping them explicit is clearer than abstracting them away; this
+        # still catches any substantive (>=30-node) duplication.
+        {Credo.Check.Design.DuplicatedCode, mass_threshold: 30, nodes_threshold: 2},
         {Credo.Check.Design.TagTODO, false},
         {Credo.Check.Design.TagFIXME, false},
         {Credo.Check.Readability.FunctionNames},

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
         run: mix format --check-formatted
       - name: Compile (warnings as errors)
         run: mix compile --force --warnings-as-errors
+      - name: Credo
+        run: mix credo
       - name: Dialyzer
         run: mix dialyzer --format github
       # No Neo4j in this job: verifies the unit suite passes with no database,

--- a/lib/bolty.ex
+++ b/lib/bolty.ex
@@ -3,7 +3,40 @@
 
 defmodule Bolty do
   @moduledoc """
-  Bolt driver for Elixir.
+  Bolt driver for Elixir — talk to Neo4j (and other Bolt servers) over the
+  binary Bolt protocol.
+
+  Bolty is built on [DBConnection](https://hexdocs.pm/db_connection), so a
+  connection is a supervised, pooled process: start one with `start_link/1`
+  (or via `child_spec/1` in a supervision tree) and query it with `query/4` /
+  `query_many/4`.
+
+  ## Example
+
+  ```elixir
+  {:ok, conn} =
+    Bolty.start_link(
+      hostname: "localhost",
+      auth: [username: "neo4j", password: "password"]
+    )
+
+  {:ok, %Bolty.Response{} = res} =
+    Bolty.query(conn, "MATCH (n:Person) RETURN n.name AS name LIMIT $limit", %{limit: 5})
+
+  # A Response is Enumerable over its result rows
+  names = Enum.map(res, & &1["name"])
+  ```
+
+  See `start_link/1` for the full connection options (TLS, pooling, auth). Every
+  failure — connection, TLS, version negotiation, and Neo4j server errors — is
+  surfaced as a `Bolty.Error`, so callers can match a single error shape.
+
+  ## Guides
+
+  - [Public API & compatibility boundary](public_api.md) — what is supported
+    under semantic versioning
+  - [Telemetry](telemetry.md) — the `[:bolty, :query]` span and other events
+  - `usage-rules.md` — an agent-facing quick reference (shipped in the package)
   """
 
   @type conn() :: DBConnection.conn()
@@ -198,6 +231,10 @@ defmodule Bolty do
     do_query(conn, queries, formatted_params, opts)
   end
 
+  @doc """
+  Same as `query_many/4`, but returns the list of `Bolty.Response` structs
+  directly and raises the `Bolty.Error` from the first failing statement.
+  """
   @spec query_many!(conn(), String.t(), map(), keyword()) :: [Bolty.Response.t()]
   def query_many!(conn, statement, params \\ %{}, opts \\ []) do
     case query_many(conn, statement, params, opts) do

--- a/lib/bolty/bolt_protocol/message/begin_message.ex
+++ b/lib/bolty/bolt_protocol/message/begin_message.ex
@@ -15,11 +15,7 @@ defmodule Bolty.BoltProtocol.Message.BeginMessage do
   end
 
   def encode(_, _) do
-    {:error,
-     Bolty.Error.wrap(__MODULE__, %{
-       code: :unsupported_message_version,
-       message: "BEGIN message version not supported"
-     })}
+    MessageEncoder.unsupported_version_error(__MODULE__, "BEGIN")
   end
 
   defp get_extra_parameters(extra_parameters) do

--- a/lib/bolty/bolt_protocol/message/commit_message.ex
+++ b/lib/bolty/bolt_protocol/message/commit_message.ex
@@ -14,10 +14,6 @@ defmodule Bolty.BoltProtocol.Message.CommitMessage do
   end
 
   def encode(_) do
-    {:error,
-     Bolty.Error.wrap(__MODULE__, %{
-       code: :unsupported_message_version,
-       message: "COMMIT message version not supported"
-     })}
+    MessageEncoder.unsupported_version_error(__MODULE__, "COMMIT")
   end
 end

--- a/lib/bolty/bolt_protocol/message/discard_message.ex
+++ b/lib/bolty/bolt_protocol/message/discard_message.ex
@@ -4,42 +4,22 @@
 defmodule Bolty.BoltProtocol.Message.DiscardMessage do
   @moduledoc false
 
+  alias Bolty.BoltProtocol.MessageDecoder
   alias Bolty.BoltProtocol.MessageEncoder
 
   @signature 0x2F
 
   def encode(bolt_version, extra_parameters)
       when is_tuple(bolt_version) and bolt_version >= {4, 0} do
-    message = [get_extra_parameters(extra_parameters)]
+    message = [MessageEncoder.paging_params(extra_parameters)]
     MessageEncoder.encode(@signature, message)
   end
 
   def encode(_, _) do
-    {:error,
-     Bolty.Error.wrap(__MODULE__, %{
-       code: :unsupported_message_version,
-       message: "DISCARD message version not supported"
-     })}
+    MessageEncoder.unsupported_version_error(__MODULE__, "DISCARD")
   end
 
   def prepare_messages(_bolt_version, messages) do
-    case hd(messages) do
-      {:success, response} ->
-        {:ok, response}
-
-      {:failure, response} ->
-        {:error,
-         Bolty.Error.wrap(__MODULE__, %{
-           code: response["neo4j_code"] || response["code"],
-           message: response["description"] || response["message"]
-         })}
-    end
-  end
-
-  defp get_extra_parameters(extra_parameters) do
-    %{
-      n: Map.get(extra_parameters, :n, -1),
-      qid: Map.get(extra_parameters, :qid, -1)
-    }
+    MessageDecoder.prepare_generic(__MODULE__, messages)
   end
 end

--- a/lib/bolty/bolt_protocol/message/goodbye_message.ex
+++ b/lib/bolty/bolt_protocol/message/goodbye_message.ex
@@ -13,10 +13,6 @@ defmodule Bolty.BoltProtocol.Message.GoodbyeMessage do
   end
 
   def encode(_) do
-    {:error,
-     Bolty.Error.wrap(__MODULE__, %{
-       code: :unsupported_message_version,
-       message: "GOODBYE message version not supported"
-     })}
+    MessageEncoder.unsupported_version_error(__MODULE__, "GOODBYE")
   end
 end

--- a/lib/bolty/bolt_protocol/message/hello_message.ex
+++ b/lib/bolty/bolt_protocol/message/hello_message.ex
@@ -29,11 +29,7 @@ defmodule Bolty.BoltProtocol.Message.HelloMessage do
   end
 
   def encode(_, _) do
-    {:error,
-     Bolty.Error.wrap(__MODULE__, %{
-       code: :unsupported_message_version,
-       message: "HELLO message version not supported"
-     })}
+    MessageEncoder.unsupported_version_error(__MODULE__, "HELLO")
   end
 
   defp get_extra_parameters(policy, fields) do

--- a/lib/bolty/bolt_protocol/message/logoff_message.ex
+++ b/lib/bolty/bolt_protocol/message/logoff_message.ex
@@ -13,10 +13,6 @@ defmodule Bolty.BoltProtocol.Message.LogoffMessage do
   end
 
   def encode(_) do
-    {:error,
-     Bolty.Error.wrap(__MODULE__, %{
-       code: :unsupported_message_version,
-       message: "LOGOFF message version not supported"
-     })}
+    MessageEncoder.unsupported_version_error(__MODULE__, "LOGOFF")
   end
 end

--- a/lib/bolty/bolt_protocol/message/logon_message.ex
+++ b/lib/bolty/bolt_protocol/message/logon_message.ex
@@ -16,10 +16,6 @@ defmodule Bolty.BoltProtocol.Message.LogonMessage do
   end
 
   def encode(_, _) do
-    {:error,
-     Bolty.Error.wrap(__MODULE__, %{
-       code: :unsupported_message_version,
-       message: "LOGON message version not supported"
-     })}
+    MessageEncoder.unsupported_version_error(__MODULE__, "LOGON")
   end
 end

--- a/lib/bolty/bolt_protocol/message/pull_message.ex
+++ b/lib/bolty/bolt_protocol/message/pull_message.ex
@@ -6,22 +6,19 @@ defmodule Bolty.BoltProtocol.Message.PullMessage do
 
   import Bolty.BoltProtocol.ServerResponse
 
+  alias Bolty.BoltProtocol.MessageDecoder
   alias Bolty.BoltProtocol.MessageEncoder
 
   @signature 0x3F
 
   def encode(bolt_version, extra_parameters)
       when is_tuple(bolt_version) and bolt_version >= {4, 0} do
-    message = [get_extra_parameters(extra_parameters)]
+    message = [MessageEncoder.paging_params(extra_parameters)]
     MessageEncoder.encode(@signature, message)
   end
 
   def encode(_, _) do
-    {:error,
-     Bolty.Error.wrap(__MODULE__, %{
-       code: :unsupported_message_version,
-       message: "PULL message version not supported"
-     })}
+    MessageEncoder.unsupported_version_error(__MODULE__, "PULL")
   end
 
   def prepare_messages(_bolt_version, messages) do
@@ -32,11 +29,7 @@ defmodule Bolty.BoltProtocol.Message.PullMessage do
         {:error, Bolty.Error.wrap(__MODULE__, :ignored)}
 
       List.keymember?(messages, :failure, 0) ->
-        {:error,
-         Bolty.Error.wrap(__MODULE__, %{
-           code: messages[:failure]["neo4j_code"] || messages[:failure]["code"],
-           message: messages[:failure]["description"] || messages[:failure]["message"]
-         })}
+        {:error, MessageDecoder.failure_error(__MODULE__, messages[:failure])}
 
       true ->
         {:ok, pull_result(records: records, success_data: messages[:success])}
@@ -45,13 +38,6 @@ defmodule Bolty.BoltProtocol.Message.PullMessage do
 
   def format_error(:unsupported_message_version), do: "PULL message version not supported"
   def format_error(_), do: "unknown error from PULL response"
-
-  defp get_extra_parameters(extra_parameters) do
-    %{
-      n: Map.get(extra_parameters, :n, -1),
-      qid: Map.get(extra_parameters, :qid, -1)
-    }
-  end
 
   defp group_record({:record, data}, acc) do
     [data | acc]

--- a/lib/bolty/bolt_protocol/message/reset_message.ex
+++ b/lib/bolty/bolt_protocol/message/reset_message.ex
@@ -13,10 +13,6 @@ defmodule Bolty.BoltProtocol.Message.ResetMessage do
   end
 
   def encode(_) do
-    {:error,
-     Bolty.Error.wrap(__MODULE__, %{
-       code: :unsupported_message_version,
-       message: "RESET message version not supported"
-     })}
+    MessageEncoder.unsupported_version_error(__MODULE__, "RESET")
   end
 end

--- a/lib/bolty/bolt_protocol/message/rollback_message.ex
+++ b/lib/bolty/bolt_protocol/message/rollback_message.ex
@@ -14,10 +14,6 @@ defmodule Bolty.BoltProtocol.Message.RollbackMessage do
   end
 
   def encode(_) do
-    {:error,
-     Bolty.Error.wrap(__MODULE__, %{
-       code: :unsupported_message_version,
-       message: "ROLLBACK message version not supported"
-     })}
+    MessageEncoder.unsupported_version_error(__MODULE__, "ROLLBACK")
   end
 end

--- a/lib/bolty/bolt_protocol/message/run_message.ex
+++ b/lib/bolty/bolt_protocol/message/run_message.ex
@@ -4,6 +4,7 @@
 defmodule Bolty.BoltProtocol.Message.RunMessage do
   @moduledoc false
 
+  alias Bolty.BoltProtocol.MessageDecoder
   alias Bolty.BoltProtocol.MessageEncoder
   alias Bolty.Policy
 
@@ -18,28 +19,11 @@ defmodule Bolty.BoltProtocol.Message.RunMessage do
   end
 
   def encode(_, _, _, _, _) do
-    {:error,
-     Bolty.Error.wrap(__MODULE__, %{
-       code: :unsupported_message_version,
-       message: "RUN message version not supported"
-     })}
+    MessageEncoder.unsupported_version_error(__MODULE__, "RUN")
   end
 
   def prepare_messages(_bolt_version, messages) do
-    case hd(messages) do
-      {:success, response} ->
-        {:ok, response}
-
-      {:ignored, _} ->
-        {:error, Bolty.Error.wrap(__MODULE__, :ignored)}
-
-      {:failure, response} ->
-        {:error,
-         Bolty.Error.wrap(__MODULE__, %{
-           code: response["neo4j_code"] || response["code"],
-           message: response["description"] || response["message"]
-         })}
-    end
+    MessageDecoder.prepare_generic(__MODULE__, messages)
   end
 
   defp get_extra_parameters(extra_parameters) do

--- a/lib/bolty/bolt_protocol/message_decoder.ex
+++ b/lib/bolty/bolt_protocol/message_decoder.ex
@@ -4,11 +4,37 @@
 defmodule Bolty.BoltProtocol.MessageDecoder do
   @moduledoc false
 
+  alias Bolty.Error
   alias Bolty.PackStream
 
   @type in_signature :: :failure | :ignored | :record | :success
   @type encoded :: <<_::16, _::_*8>>
   @type decoded :: {in_signature(), any()}
+
+  # Interpret the head of a decoded message list for a message type whose
+  # response is a single SUCCESS/FAILURE (with IGNORED possible mid-pipeline).
+  # Returns `{:ok, data}` on success, or `{:error, %Bolty.Error{}}` wrapped with
+  # `module` for context. Message modules with a richer response (e.g. PULL
+  # aggregating RECORDs) build their own result but reuse `failure_error/2`.
+  @spec prepare_generic(module(), [decoded()]) :: {:ok, any()} | {:error, Error.t()}
+  def prepare_generic(module, messages) do
+    case hd(messages) do
+      {:success, response} -> {:ok, response}
+      {:ignored, _} -> {:error, Error.wrap(module, :ignored)}
+      {:failure, response} -> {:error, failure_error(module, response)}
+    end
+  end
+
+  # Build the `%Bolty.Error{}` for a FAILURE response, reading the GQL-compliant
+  # `neo4j_code`/`description` fields (Bolt 5.7+) and falling back to the legacy
+  # `code`/`message` fields.
+  @spec failure_error(module(), map()) :: Error.t()
+  def failure_error(module, response) do
+    Error.wrap(module, %{
+      code: response["neo4j_code"] || response["code"],
+      message: response["description"] || response["message"]
+    })
+  end
 
   @tiny_struct_marker 0xB
   @success_signature 0x70

--- a/lib/bolty/bolt_protocol/message_encoder.ex
+++ b/lib/bolty/bolt_protocol/message_encoder.ex
@@ -25,6 +25,29 @@ defmodule Bolty.BoltProtocol.MessageEncoder do
     encoded |> IO.iodata_to_binary()
   end
 
+  # The standard `{:error, %Bolty.Error{}}` a message module returns from its
+  # fallback `encode/_` clause when the negotiated Bolt version is too old to
+  # carry that message. `module` is the calling message module (for error
+  # context); `name` is the message name, e.g. `"RUN"`.
+  @spec unsupported_version_error(module(), String.t()) :: {:error, Bolty.Error.t()}
+  def unsupported_version_error(module, name) do
+    {:error,
+     Bolty.Error.wrap(module, %{
+       code: :unsupported_message_version,
+       message: "#{name} message version not supported"
+     })}
+  end
+
+  # The `n`/`qid` paging fields shared by the PULL and DISCARD message extras,
+  # each defaulting to `-1` (all records / the last query).
+  @spec paging_params(map()) :: %{n: integer(), qid: integer()}
+  def paging_params(extra_parameters) do
+    %{
+      n: Map.get(extra_parameters, :n, -1),
+      qid: Map.get(extra_parameters, :qid, -1)
+    }
+  end
+
   defp do_encode(signature, list, policy) when length(list) <= 15 do
     [
       <<@tiny_struct_marker::4, length(list)::4, signature>>,

--- a/lib/bolty/bolt_protocol/versions.ex
+++ b/lib/bolty/bolt_protocol/versions.ex
@@ -81,43 +81,35 @@ defmodule Bolty.BoltProtocol.Versions do
   @spec rangeify([version()]) :: [version() | version_range()]
   def rangeify(list) when is_list(list) do
     list
-    |> Enum.reduce([], fn {major, minor} = value, acc ->
-      cond do
-        acc == [] ->
-          [value]
-
-        major < 4 ->
-          [value | acc]
-
-        major == 4 and minor < 3 ->
-          [value | acc]
-
-        true ->
-          [{prev_major, prev_minor_or_range} | tail] = acc
-
-          cond do
-            major < prev_major ->
-              [value | acc]
-
-            is_integer(prev_minor_or_range) ->
-              if minor + 1 == prev_minor_or_range do
-                [{prev_major, Range.new(minor, prev_minor_or_range)} | tail]
-              else
-                [value | acc]
-              end
-
-            true ->
-              if minor + 1 == prev_minor_or_range.first do
-                [
-                  {prev_major, Range.new(minor, List.last(Range.to_list(prev_minor_or_range)))}
-                  | tail
-                ]
-              else
-                [value | acc]
-              end
-          end
-      end
-    end)
+    |> Enum.reduce([], &coalesce/2)
     |> Enum.reverse()
   end
+
+  # Fold one version into the accumulated (reversed) list, merging it into the
+  # previous entry's range when the two are numerically adjacent, otherwise
+  # prepending it. Versions below 4.3 are never range-merged.
+  defp coalesce({major, minor} = value, acc) do
+    cond do
+      acc == [] -> [value]
+      major < 4 -> [value | acc]
+      major == 4 and minor < 3 -> [value | acc]
+      true -> merge_with_previous(value, acc)
+    end
+  end
+
+  defp merge_with_previous({major, minor} = value, [{prev_major, prev} | tail] = acc) do
+    cond do
+      major < prev_major -> [value | acc]
+      adjacent?(minor, prev) -> [{prev_major, extend_range(minor, prev)} | tail]
+      true -> [value | acc]
+    end
+  end
+
+  defp adjacent?(minor, prev) when is_integer(prev), do: minor + 1 == prev
+  defp adjacent?(minor, %Range{} = prev), do: minor + 1 == prev.first
+
+  defp extend_range(minor, prev) when is_integer(prev), do: Range.new(minor, prev)
+
+  defp extend_range(minor, %Range{} = prev),
+    do: Range.new(minor, List.last(Range.to_list(prev)))
 end

--- a/lib/bolty/client.ex
+++ b/lib/bolty/client.ex
@@ -539,9 +539,8 @@ defmodule Bolty.Client do
   end
 
   defp get_next_message(client, timeout) do
-    with {:ok, message_binary} <- read_chunks(client, timeout, <<>>),
-         {:ok, message} <- decode_message(message_binary) do
-      {:ok, message}
+    with {:ok, message_binary} <- read_chunks(client, timeout, <<>>) do
+      decode_message(message_binary)
     end
   end
 

--- a/lib/bolty/client.ex
+++ b/lib/bolty/client.ex
@@ -334,55 +334,32 @@ defmodule Bolty.Client do
   end
 
   def prepare_generic_messages(_bolt_version, messages) do
-    response = hd(messages)
-
-    case response do
-      {:success, response} ->
-        {:ok, response}
-
-      {:ignored, _} ->
-        {:error, Bolty.Error.wrap(__MODULE__, :ignored)}
-
-      {:failure, response} ->
-        {:error,
-         Bolty.Error.wrap(__MODULE__, %{
-           code: response["neo4j_code"] || response["code"],
-           message: response["description"] || response["message"]
-         })}
-    end
+    MessageDecoder.prepare_generic(__MODULE__, messages)
   end
 
   def send_hello(client, fields) do
     payload = HelloMessage.encode(client.bolt_version, [{:policy, client.policy} | fields])
 
-    with :ok <- send_packet(client, payload) do
-      recv_packets(client, &__MODULE__.prepare_generic_messages/2, client.recv_timeout)
-    end
+    send_and_recv(client, payload, &__MODULE__.prepare_generic_messages/2)
   end
 
   def send_logon(client, fields) do
     payload = LogonMessage.encode(client.bolt_version, fields)
 
-    with :ok <- send_packet(client, payload) do
-      recv_packets(client, &__MODULE__.prepare_generic_messages/2, client.recv_timeout)
-    end
+    send_and_recv(client, payload, &__MODULE__.prepare_generic_messages/2)
   end
 
   def send_run(client, query, parameters, extra_parameters) do
     payload =
       RunMessage.encode(client.bolt_version, query, parameters, extra_parameters, client.policy)
 
-    with :ok <- send_packet(client, payload) do
-      recv_packets(client, &RunMessage.prepare_messages/2, client.recv_timeout)
-    end
+    send_and_recv(client, payload, &RunMessage.prepare_messages/2)
   end
 
   def send_pull(client, extra_parameters) do
     payload = PullMessage.encode(client.bolt_version, extra_parameters)
 
-    with :ok <- send_packet(client, payload) do
-      recv_packets(client, &PullMessage.prepare_messages/2, client.recv_timeout)
-    end
+    send_and_recv(client, payload, &PullMessage.prepare_messages/2)
   end
 
   def run_statement(client, query, parameters, extra_parameters) do
@@ -417,41 +394,31 @@ defmodule Bolty.Client do
   def send_begin(client, extra_parameters) do
     payload = BeginMessage.encode(client.bolt_version, extra_parameters)
 
-    with :ok <- send_packet(client, payload) do
-      recv_packets(client, &__MODULE__.prepare_generic_messages/2, client.recv_timeout)
-    end
+    send_and_recv(client, payload, &__MODULE__.prepare_generic_messages/2)
   end
 
   def send_commit(client) do
     payload = CommitMessage.encode(client.bolt_version)
 
-    with :ok <- send_packet(client, payload) do
-      recv_packets(client, &__MODULE__.prepare_generic_messages/2, client.recv_timeout)
-    end
+    send_and_recv(client, payload, &__MODULE__.prepare_generic_messages/2)
   end
 
   def send_rollback(client) do
     payload = RollbackMessage.encode(client.bolt_version)
 
-    with :ok <- send_packet(client, payload) do
-      recv_packets(client, &__MODULE__.prepare_generic_messages/2, client.recv_timeout)
-    end
+    send_and_recv(client, payload, &__MODULE__.prepare_generic_messages/2)
   end
 
   def send_reset(client) do
     payload = ResetMessage.encode(client.bolt_version)
 
-    with :ok <- send_packet(client, payload) do
-      recv_packets(client, &__MODULE__.prepare_generic_messages/2, client.recv_timeout)
-    end
+    send_and_recv(client, payload, &__MODULE__.prepare_generic_messages/2)
   end
 
   def send_discard(client, extra_parameters) do
     payload = DiscardMessage.encode(client.bolt_version, extra_parameters)
 
-    with :ok <- send_packet(client, payload) do
-      recv_packets(client, &DiscardMessage.prepare_messages/2, client.recv_timeout)
-    end
+    send_and_recv(client, payload, &DiscardMessage.prepare_messages/2)
   end
 
   def send_goodbye(client) do
@@ -475,9 +442,7 @@ defmodule Bolty.Client do
   def send_logoff(client) do
     payload = LogoffMessage.encode(client.bolt_version)
 
-    with :ok <- send_packet(client, payload) do
-      recv_packets(client, &__MODULE__.prepare_generic_messages/2, client.recv_timeout)
-    end
+    send_and_recv(client, payload, &__MODULE__.prepare_generic_messages/2)
   end
 
   # Keepalive for idle pooled connections (see `Connection.ping/1`). RESET is a
@@ -499,6 +464,15 @@ defmodule Bolty.Client do
 
   def send_packet(client, payload) do
     send_data(client, payload)
+  end
+
+  # Send an already-encoded message and read the response with the given
+  # `prepare_messages/2` interpreter. The common body of the `send_*` helpers;
+  # `send_goodbye/1` is the exception (it tears the port down on `:closed`).
+  defp send_and_recv(client, payload, prepare_messages) do
+    with :ok <- send_packet(client, payload) do
+      recv_packets(client, prepare_messages, client.recv_timeout)
+    end
   end
 
   def send_data(%{sock: {sock_mod, sock}}, data) do

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,6 @@ defmodule Bolty.Mixfile do
       package: package(),
       description: "Neo4j driver for Elixir, using the fast Bolt protocol",
       name: "Bolty",
-      build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       docs: docs(),
       dialyzer: [
@@ -58,10 +57,7 @@ defmodule Bolty.Mixfile do
 
   defp aliases do
     [
-      setup: ["deps.get", &enable_git_hooks/1],
-      test: [
-        "test"
-      ]
+      setup: ["deps.get", &enable_git_hooks/1]
     ]
   end
 


### PR DESCRIPTION
Closes #78. Also ticks the `mix credo` box on #80.

Most of the original #78 list already landed (source_url, README, usage-rules packaging via #90; `query_many/4` doc via #79), so this PR is the remainder, one commit per concern.

## `docs:` expand the Bolty landing moduledoc + doc query_many!/4
Turn the one-line `Bolty` moduledoc into a real landing page (what the driver is, a minimal start_link/query example — fenced, not a doctest — the single-error-shape guarantee, links to the public-API/telemetry/usage-rules guides). Add the missing `@doc` to `query_many!/4`.

## `chore:` drop obsolete build_embedded + no-op test alias
`build_embedded: Mix.env() == :prod` is a long-dead no-op; `test: ["test"]` just shadows the built-in task with itself.

## `refactor:` clear the credo refactoring findings
- `Client.get_next_message`: drop the redundant final `with` clause (it matched `{:ok, message}` only to rebuild it) — return `decode_message/1`'s result directly.
- `Versions.rangeify`: extract the nested reduce/cond into `coalesce/2`, `merge_with_previous/2`, `adjacent?/2`, `extend_range/2`. Behaviour unchanged (versions_test green).

## `refactor:` deduplicate the Bolt message boilerplate
The bulk of the credo work. Factor the genuine copy-paste into shared helpers:
- `MessageDecoder.prepare_generic/2` — the success/ignored/failure handler that `Client.prepare_generic_messages` and `RunMessage`/`DiscardMessage` reimplemented verbatim; they delegate now, passing their own `__MODULE__` so error attribution is unchanged (`DiscardMessage` also gains graceful `:ignored` handling instead of a `CaseClauseError`).
- `MessageDecoder.failure_error/2` — the GQL-vs-legacy failure-field extraction copy-pasted in four places.
- `MessageEncoder.unsupported_version_error/2` — the identical fallback `encode/_` error across all 11 message modules.
- `MessageEncoder.paging_params/1` — the shared `n`/`qid` extras for PULL/DISCARD.
- `Client.send_and_recv/3` — the `send_packet` + `recv_packets` body repeated across the `send_*` helpers.

**Residual, by decision:** the tiny, deliberately-parallel `encode/_` clauses that differ only by signature/name (COMMIT/ROLLBACK, RESET/GOODBYE, DISCARD/PULL) are left explicit; `DuplicatedCode` `mass_threshold` goes 16 → 30 rather than hiding one-module-per-message behind a macro. (27 → 0 findings.)

## `ci:` run mix credo in the static-analysis job
Credo was configured but never run. Added to the lint job, **non-strict** (the `--strict` line-length pass is deferred).

## Verification
- `mix format --check-formatted`, `mix compile --force --warnings-as-errors`, **`mix credo` (exit 0)**, `mix dialyzer` (0 errors) all clean.
- `mix docs` builds with no warnings.
- Full suite against local Neo4j (5.26.28, Bolt 5.4): **344 tests, 3 properties** — the message-path refactor preserves behaviour.