### PR TITLE
fix: wrap handshake failures as %Bolty.Error{} instead of crashing (#106)

### DIFF
--- a/lib/bolty/client.ex
+++ b/lib/bolty/client.ex
@@ -321,15 +321,16 @@ defmodule Bolty.Client do
          |> Enum.reduce(<<>>, fn version, acc -> acc <> Versions.to_bytes(version) end))
 
     with :ok <- send_packet(client, data),
-         encode_version <- recv_packets(client, config.connect_timeout),
-         version <- decode_version(encode_version) do
-      case version do
+         response when is_binary(response) <- recv_packets(client, config.connect_timeout),
+         {major, minor} <- decode_version(response) do
+      case {major, minor} do
         {0, 0} -> {:error, Bolty.Error.wrap(__MODULE__, :version_negotiation_error)}
-        _ -> {:ok, %{client | bolt_version: version}}
+        version -> {:ok, %{client | bolt_version: version}}
       end
     else
-      _ ->
-        {:error, Bolty.Error.wrap(__MODULE__, :version_negotiation_error)}
+      {:error, %Bolty.Error{}} = error -> error
+      {:error, reason} -> {:error, wrap_connect_error(reason)}
+      _ -> {:error, Bolty.Error.wrap(__MODULE__, :version_negotiation_error)}
     end
   end
 
@@ -462,6 +463,8 @@ defmodule Bolty.Client do
     {major, minor}
   end
 
+  defp decode_version(_other), do: :error
+
   def send_packet(client, payload) do
     send_data(client, payload)
   end
@@ -484,11 +487,8 @@ defmodule Bolty.Client do
       {:ok, response} ->
         response
 
-      {:error, :timeout} ->
-        {:error, Bolty.Error.wrap(__MODULE__, :timeout)}
-
-      {:error, _} = error ->
-        error
+      {:error, reason} ->
+        {:error, wrap_connect_error(reason)}
     end
   end
 

--- a/test/bolty/client_handshake_test.exs
+++ b/test/bolty/client_handshake_test.exs
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Bolty.ClientHandshakeTest do
+  use ExUnit.Case, async: true
+
+  # Regression coverage for #106: a server that misbehaves during the
+  # handshake (closes early, or replies with something that isn't a
+  # well-formed <<0, 0, minor, major>> version response) must surface as a
+  # clean %Bolty.Error{}, not crash the connect attempt with a raw
+  # FunctionClauseError. No live Neo4j needed — a bare TCP stub is enough to
+  # exercise the handshake decode path, so this runs under plain `mix test`.
+
+  alias Bolty.Client
+
+  defp start_stub_server(handler) do
+    {:ok, listen_socket} =
+      :gen_tcp.listen(0, [:binary, packet: :raw, active: false, reuseaddr: true])
+
+    {:ok, port} = :inet.port(listen_socket)
+
+    {:ok, _pid} =
+      Task.start_link(fn ->
+        {:ok, socket} = :gen_tcp.accept(listen_socket)
+        handler.(socket)
+      end)
+
+    port
+  end
+
+  defp connect_opts(port) do
+    [
+      hostname: "127.0.0.1",
+      port: port,
+      scheme: "bolt",
+      auth: [username: "neo4j", password: "password"],
+      connect_timeout: 1_000
+    ]
+  end
+
+  test "server closing the connection mid-handshake returns a clean %Bolty.Error{}" do
+    port =
+      start_stub_server(fn socket ->
+        :gen_tcp.close(socket)
+      end)
+
+    assert {:error, %Bolty.Error{}} = Client.connect(connect_opts(port))
+  end
+
+  test "server replying with a malformed handshake response returns a clean %Bolty.Error{}" do
+    port =
+      start_stub_server(fn socket ->
+        # Drain whatever the client sent, then reply with bytes that don't
+        # match the <<0, 0, minor, major>> version-response shape at all.
+        :gen_tcp.recv(socket, 0, 1_000)
+        :gen_tcp.send(socket, <<9, 9, 9, 9>>)
+      end)
+
+    assert {:error, %Bolty.Error{}} = Client.connect(connect_opts(port))
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #106, the last gap in the P0-2 "always return `%Bolty.Error{}`, never raise" guarantee — flagged in the second-pass industrialisation re-audit.

`do_handshake/2`'s `with` bound `recv_packets/2`'s result to a bare variable, so on a socket failure during the handshake read (server closes early, garbage reply, etc.) the resulting `{:error, reason}` tuple got passed straight into `decode_version/1` — which only has one clause matching a well-formed 4-byte version response — raising a `FunctionClauseError` inside the connect callback instead of returning a clean error.

## Changes

- `do_handshake/2`: guard the `with` clause on `is_binary/1` so a recv failure routes to `else` instead of being blindly bound and forwarded into `decode_version/1`.
- `decode_version/1`: added a fallback clause returning `:error` for any non-matching binary, instead of raising on malformed/short replies.
- `recv_packets/2`: unified to wrap *every* recv failure via the existing `wrap_connect_error/1` helper (previously only `:timeout` was wrapped; other reasons like `{:error, :closed}` passed through raw, un-wrapped).

## Test plan

- [x] Added `test/bolty/client_handshake_test.exs` — a bare TCP stub server (no live Neo4j needed) covering "server closes mid-handshake" and "server replies with garbage bytes."
- [x] Confirmed both new tests reproduce the exact `FunctionClauseError` against the pre-fix code (verified via `git stash`), and pass cleanly with the fix.
- [x] Full suite (235 tests), `mix credo`, `mix dialyzer` all clean.