### PR TITLE
chore: remove pre-5.0 dead code + reject unsupported :versions at config time

### DIFF
--- a/lib/bolty/bolt_protocol/versions.ex
+++ b/lib/bolty/bolt_protocol/versions.ex
@@ -87,15 +87,9 @@ defmodule Bolty.BoltProtocol.Versions do
 
   # Fold one version into the accumulated (reversed) list, merging it into the
   # previous entry's range when the two are numerically adjacent, otherwise
-  # prepending it. Versions below 4.3 are never range-merged.
-  defp coalesce({major, minor} = value, acc) do
-    cond do
-      acc == [] -> [value]
-      major < 4 -> [value | acc]
-      major == 4 and minor < 3 -> [value | acc]
-      true -> merge_with_previous(value, acc)
-    end
-  end
+  # prepending it.
+  defp coalesce(value, []), do: [value]
+  defp coalesce(value, acc), do: merge_with_previous(value, acc)
 
   defp merge_with_previous({major, minor} = value, [{prev_major, prev} | tail] = acc) do
     cond do

--- a/lib/bolty/client.ex
+++ b/lib/bolty/client.ex
@@ -186,16 +186,24 @@ defmodule Bolty.Client do
     # dropped with a warning as long as at least one requested version is
     # actually supported; if none are, that's a config error, not a silent
     # fallback to bolty's defaults (the caller asked for something specific).
+    #
+    # `:versions` entries can be a plain {major, minor} or a documented
+    # {major, minor..minor} range (one handshake slot offering several
+    # minors at once). A range is classified minor-by-minor rather than as
+    # one opaque unit: if every minor in it is still supported it's kept
+    # compactly as a range, if only some are it's kept as the individual
+    # still-supported minors (e.g. after a future floor bump drops the low
+    # end of a range a caller configured), and only a range with no
+    # supported minors at all is dropped entirely.
     defp reject_unsupported_versions(raw_versions, parsed_versions) do
       supported = Versions.available_versions()
+      classified = Enum.map(parsed_versions, &classify_version(&1, supported))
 
-      {ok, rejected} =
-        raw_versions
-        |> Enum.zip(parsed_versions)
-        |> Enum.split_with(fn {_raw, canonical} -> canonical in supported end)
+      kept = Enum.flat_map(classified, & &1.kept)
+      dropped = Enum.flat_map(classified, & &1.dropped)
 
-      case {ok, rejected} do
-        {[], _rejected} ->
+      cond do
+        kept == [] ->
           {:error,
            Bolty.Error.wrap(Bolty.Client, %{
              code: :unsupported_versions,
@@ -205,21 +213,44 @@ defmodule Bolty.Client do
                  Enum.map_join(supported, ", ", &Versions.format/1)
            })}
 
-        {ok, []} ->
-          {:ok, pad_and_sort(Enum.map(ok, &elem(&1, 1)))}
-
-        {ok, rejected} ->
+        dropped != [] ->
           require Logger
 
-          rejected_raw = Enum.map(rejected, &elem(&1, 0))
-
           Logger.warning(
-            "bolty: dropping unsupported Bolt version(s) #{inspect(rejected_raw)} from " <>
-              ":versions — bolty only supports " <>
+            "bolty: dropping unsupported Bolt version(s) " <>
+              "#{Enum.map_join(dropped, ", ", &Versions.format/1)} from :versions " <>
+              "(requested #{inspect(raw_versions)}) — bolty only supports " <>
               Enum.map_join(supported, ", ", &Versions.format/1)
           )
 
-          {:ok, pad_and_sort(Enum.map(ok, &elem(&1, 1)))}
+          {:ok, pad_and_sort(kept)}
+
+        true ->
+          {:ok, pad_and_sort(kept)}
+      end
+    end
+
+    defp classify_version({_major, minor} = canonical, supported) when is_integer(minor) do
+      if canonical in supported do
+        %{kept: [canonical], dropped: []}
+      else
+        %{kept: [], dropped: [canonical]}
+      end
+    end
+
+    defp classify_version({major, %Range{} = range}, supported) do
+      {kept_minors, dropped_minors} =
+        range |> Enum.to_list() |> Enum.split_with(&({major, &1} in supported))
+
+      case {kept_minors, dropped_minors} do
+        {_, []} ->
+          %{kept: [{major, range}], dropped: []}
+
+        {[], _} ->
+          %{kept: [], dropped: Enum.map(dropped_minors, &{major, &1})}
+
+        {kept, dropped} ->
+          %{kept: Enum.map(kept, &{major, &1}), dropped: Enum.map(dropped, &{major, &1})}
       end
     end
 

--- a/lib/bolty/client.ex
+++ b/lib/bolty/client.ex
@@ -56,22 +56,18 @@ defmodule Bolty.Client do
     Builds a `%Config{}` from connection options.
 
     Returns `{:ok, config}`, or `{:error, %Bolty.Error{}}` when a required field
-    (currently `:username`) is missing — the caller surfaces that cleanly rather
-    than raising inside DBConnection's connect callback.
+    (currently `:username`) is missing, or when `:versions` contains no version
+    bolty actually implements — either way the caller surfaces that cleanly
+    rather than raising (or silently misbehaving) inside DBConnection's connect
+    callback.
     """
     def new(opts) do
       {hostname, port} = get_hostname_and_port(opts)
       {username, password} = get_user_and_pass(opts)
       {scheme, ssl?, tls_verify, ssl_opts} = get_scheme_and_ssl_opts(opts)
-      versions = get_versions(opts)
 
-      if is_nil(username) do
-        {:error,
-         Bolty.Error.wrap(Bolty.Client, %{
-           code: :missing_username,
-           message: ":username is missing — set auth: [username: ...] in your connection config"
-         })}
-      else
+      with :ok <- validate_username(username),
+           {:ok, versions} <- get_versions(opts) do
         {:ok,
          %__MODULE__{
            hostname: hostname,
@@ -93,6 +89,16 @@ defmodule Bolty.Client do
          }}
       end
     end
+
+    defp validate_username(nil) do
+      {:error,
+       Bolty.Error.wrap(Bolty.Client, %{
+         code: :missing_username,
+         message: ":username is missing — set auth: [username: ...] in your connection config"
+       })}
+    end
+
+    defp validate_username(_username), do: :ok
 
     # Maps the connection scheme to a TLS *intent*, not materialised ssl options:
     # the strict defaults (incl. SNI, which needs the hostname) are built at
@@ -149,7 +155,7 @@ defmodule Bolty.Client do
     def get_versions(opts) do
       case Keyword.get(opts, :versions) do
         nil ->
-          Versions.latest_versions()
+          {:ok, Versions.latest_versions()}
 
         versions ->
           {parsed, deprecated_float?} =
@@ -167,8 +173,58 @@ defmodule Bolty.Client do
             )
           end
 
-          (parsed ++ [{0, 0}, {0, 0}, {0, 0}]) |> Enum.take(4) |> Enum.sort(&>=/2)
+          reject_unsupported_versions(versions, parsed)
       end
+    end
+
+    # bolty only ever negotiates versions it actually implements — a version
+    # that isn't in Versions.available_versions() (e.g. a pre-5.0 Bolt version,
+    # or one bolty hasn't caught up to yet) must never reach the handshake
+    # bytes: if a server somehow *did* accept it, bolty's own message/policy
+    # code doesn't speak that dialect and would fail confusingly deep in
+    # encode/decode instead of cleanly at connect. Unsupported entries are
+    # dropped with a warning as long as at least one requested version is
+    # actually supported; if none are, that's a config error, not a silent
+    # fallback to bolty's defaults (the caller asked for something specific).
+    defp reject_unsupported_versions(raw_versions, parsed_versions) do
+      supported = Versions.available_versions()
+
+      {ok, rejected} =
+        raw_versions
+        |> Enum.zip(parsed_versions)
+        |> Enum.split_with(fn {_raw, canonical} -> canonical in supported end)
+
+      case {ok, rejected} do
+        {[], _rejected} ->
+          {:error,
+           Bolty.Error.wrap(Bolty.Client, %{
+             code: :unsupported_versions,
+             message:
+               "none of the requested :versions #{inspect(raw_versions)} are supported by " <>
+                 "bolty; supported versions are " <>
+                 Enum.map_join(supported, ", ", &Versions.format/1)
+           })}
+
+        {ok, []} ->
+          {:ok, pad_and_sort(Enum.map(ok, &elem(&1, 1)))}
+
+        {ok, rejected} ->
+          require Logger
+
+          rejected_raw = Enum.map(rejected, &elem(&1, 0))
+
+          Logger.warning(
+            "bolty: dropping unsupported Bolt version(s) #{inspect(rejected_raw)} from " <>
+              ":versions — bolty only supports " <>
+              Enum.map_join(supported, ", ", &Versions.format/1)
+          )
+
+          {:ok, pad_and_sort(Enum.map(ok, &elem(&1, 1)))}
+      end
+    end
+
+    defp pad_and_sort(versions) do
+      (versions ++ [{0, 0}, {0, 0}, {0, 0}]) |> Enum.take(4) |> Enum.sort(&>=/2)
     end
   end
 

--- a/lib/bolty/client.ex
+++ b/lib/bolty/client.ex
@@ -250,7 +250,18 @@ defmodule Bolty.Client do
           %{kept: [], dropped: Enum.map(dropped_minors, &{major, &1})}
 
         {kept, dropped} ->
-          %{kept: Enum.map(kept, &{major, &1}), dropped: Enum.map(dropped, &{major, &1})}
+          # Only 4 handshake slots exist in total (see pad_and_sort/1), so a
+          # partially-supported range must stay as compact as possible rather
+          # than exploding into one slot per surviving minor — re-coalesce any
+          # contiguous survivors back into range slot(s) with the same logic
+          # latest_versions/0 uses to build the default offer.
+          recompacted =
+            kept
+            |> Enum.map(&{major, &1})
+            |> Enum.sort(&>=/2)
+            |> Versions.rangeify()
+
+          %{kept: recompacted, dropped: Enum.map(dropped, &{major, &1})}
       end
     end
 

--- a/lib/bolty/pack_stream/markers.ex
+++ b/lib/bolty/pack_stream/markers.ex
@@ -80,17 +80,9 @@ defmodule Bolty.PackStream.Markers do
       @local_datetime_signature 0x64
       @local_datetime_struct_size 2
 
-      # Legacy Datetime with TZ offset
-      @legacy_datetime_with_zone_offset_signature 0x46
-      @legacy_datetime_with_zone_offset_struct_size 3
-
       # Datetime with TZ offset
       @datetime_with_zone_offset_signature 0x49
       @datetime_with_zone_offset_struct_size 3
-
-      # Legacy Datetime with TZ id
-      @legacy_datetime_with_zone_id_signature 0x66
-      @legacy_datetime_with_zone_id_struct_size 3
 
       # Datetime with TZ id
       @datetime_with_zone_id_signature 0x69

--- a/lib/bolty/pack_stream/unpacker.ex
+++ b/lib/bolty/pack_stream/unpacker.ex
@@ -248,25 +248,6 @@ defmodule Bolty.PackStream.Unpacker do
     [t | rest]
   end
 
-  # Legacy Datetime with zone Id
-  def unpack(
-        {@legacy_datetime_with_zone_id_signature, struct,
-         @legacy_datetime_with_zone_id_struct_size}
-      ) do
-    {[seconds, nanoseconds, zone_id], rest} =
-      decode_struct(struct, @legacy_datetime_with_zone_id_struct_size)
-
-    naive_dt =
-      NaiveDateTime.add(
-        ~N[1970-01-01 00:00:00.000000],
-        seconds * 1_000_000_000 + nanoseconds,
-        :nanosecond
-      )
-
-    dt = Bolty.TypesHelper.datetime_with_micro(naive_dt, zone_id)
-    [dt | rest]
-  end
-
   # Datetime with zone Id
   def unpack({@datetime_with_zone_id_signature, struct, @datetime_with_zone_id_struct_size}) do
     {[seconds, nanoseconds, zone_id], rest} =
@@ -285,25 +266,6 @@ defmodule Bolty.PackStream.Unpacker do
       end
 
     [datetime | rest]
-  end
-
-  # Legacy Datetime with zone offset
-  def unpack(
-        {@legacy_datetime_with_zone_offset_signature, struct,
-         @legacy_datetime_with_zone_offset_struct_size}
-      ) do
-    {[seconds, nanoseconds, zone_offset], rest} =
-      decode_struct(struct, @legacy_datetime_with_zone_offset_struct_size)
-
-    naive_dt =
-      NaiveDateTime.add(
-        ~N[1970-01-01 00:00:00.000000],
-        seconds * 1_000_000_000 + nanoseconds,
-        :nanosecond
-      )
-
-    dt = DateTimeWithTZOffset.create(naive_dt, zone_offset)
-    [dt | rest]
   end
 
   # Datetime with zone offset

--- a/lib/bolty/policy.ex
+++ b/lib/bolty/policy.ex
@@ -16,13 +16,10 @@ defmodule Bolty.Policy do
   """
 
   @typedoc """
-  DateTime encoding dialect.
-
-    * `:legacy` — emit legacy struct tags (0x46/0x66). Required for Bolt 4.x
-      wire regardless of server version.
-    * `:evolved` — emit evolved struct tags (0x49/0x69). Required for Bolt 5.x.
+  DateTime encoding dialect. Bolty only ever negotiates Bolt 5.0+, which always
+  uses the evolved struct tags (0x49/0x69) — `:evolved` is the only value.
   """
-  @type datetime :: :legacy | :evolved
+  @type datetime :: :evolved
 
   @typedoc """
   HELLO wire field name for disabled notification categories/classifications.

--- a/lib/bolty/types_helper.ex
+++ b/lib/bolty/types_helper.ex
@@ -21,15 +21,6 @@ defmodule Bolty.TypesHelper do
   end
 
   @doc """
-  Convert NaiveDateTime and timezone into a Calendar.DateTime
-  Without losing microsecond data!
-  """
-  @spec datetime_with_micro(Calendar.naive_datetime(), String.t()) :: Calendar.datetime()
-  def datetime_with_micro(%NaiveDateTime{} = naive_dt, timezone) do
-    DateTime.from_naive!(naive_dt, timezone)
-  end
-
-  @doc """
   Convert an amount of seconds in a +hours:minutes offset
   """
   @spec formated_time_offset(integer()) :: String.t()

--- a/test/bolty/client_test.exs
+++ b/test/bolty/client_test.exs
@@ -131,6 +131,41 @@ defmodule Bolty.ClientTest do
       assert log =~ "deprecated"
     end
 
+    test "a range :versions entry that is fully supported is kept compact, no warning" do
+      import ExUnit.CaptureLog
+
+      log =
+        capture_log(fn ->
+          {:ok, config} = Client.Config.new(auth: [username: "u"], versions: [{5, 6..8}])
+          # kept as one range slot, not expanded — every minor in it is supported
+          assert config.versions == [{5, 6..8}, {0, 0}, {0, 0}, {0, 0}]
+        end)
+
+      refute log =~ "unsupported"
+    end
+
+    test "a range :versions entry spanning an unsupported minor is narrowed, with a warning" do
+      import ExUnit.CaptureLog
+
+      # {5, 5} doesn't exist in Versions.available_versions() (a real gap between
+      # 5.4 and 5.6), so this range straddles a supported/unsupported boundary
+      # exactly like a future version-floor bump would.
+      log =
+        capture_log(fn ->
+          {:ok, config} = Client.Config.new(auth: [username: "u"], versions: [{5, 4..6}])
+          assert config.versions == [{5, 6}, {5, 4}, {0, 0}, {0, 0}]
+        end)
+
+      assert log =~ "dropping unsupported Bolt version(s) 5.5"
+    end
+
+    test "a range :versions entry with no supported minors is a config error" do
+      assert {:error, %Bolty.Error{code: :unsupported_versions, bolt: %{message: message}}} =
+               Client.Config.new(auth: [username: "u"], versions: [{3, 0..2}])
+
+      assert message =~ "{3, 0..2}"
+    end
+
     test "maps schemes to the correct TLS verification intent" do
       base_opts = [
         auth: [username: "usertests"]

--- a/test/bolty/client_test.exs
+++ b/test/bolty/client_test.exs
@@ -159,6 +159,24 @@ defmodule Bolty.ClientTest do
       assert log =~ "dropping unsupported Bolt version(s) 5.5"
     end
 
+    test "surviving minors of a narrowed range are re-coalesced, not exploded into one slot each" do
+      import ExUnit.CaptureLog
+
+      # {5, 3..9} spans 7 minors; 5.5 and 5.9 don't exist in
+      # Versions.available_versions(), leaving two contiguous survivor runs
+      # (3..4 and 6..8). Only 4 handshake slots exist in total (pad_and_sort/1),
+      # so if survivors were kept as flat individual tuples instead of being
+      # re-ranged, this would need 5 slots and something would be silently
+      # dropped by the Enum.take(4) padding step.
+      log =
+        capture_log(fn ->
+          {:ok, config} = Client.Config.new(auth: [username: "u"], versions: [{5, 3..9}])
+          assert config.versions == [{5, 6..8}, {5, 3..4}, {0, 0}, {0, 0}]
+        end)
+
+      assert log =~ "dropping unsupported Bolt version(s) 5.5, 5.9"
+    end
+
     test "a range :versions entry with no supported minors is a config error" do
       assert {:error, %Bolty.Error{code: :unsupported_versions, bolt: %{message: message}}} =
                Client.Config.new(auth: [username: "u"], versions: [{3, 0..2}])

--- a/test/bolty/client_test.exs
+++ b/test/bolty/client_test.exs
@@ -244,10 +244,20 @@ defmodule Bolty.ClientTest do
 
   describe "connect" do
     @tag :bolt_version_5_3
-    test "multiple versions specified" do
+    test "multiple versions specified — unsupported entries are dropped with a warning" do
+      import ExUnit.CaptureLog
+
       opts = [versions: ["5.3", "4.0", "3.0"]] ++ @opts
-      assert {:ok, client} = Client.connect(opts)
-      assert {5, 3} == client.bolt_version
+
+      log =
+        capture_log(fn ->
+          assert {:ok, client} = Client.connect(opts)
+          assert {5, 3} == client.bolt_version
+        end)
+
+      assert log =~ "dropping unsupported Bolt version"
+      assert log =~ "4.0"
+      assert log =~ "3.0"
     end
 
     @tag :bolt_version_5_3
@@ -267,15 +277,26 @@ defmodule Bolty.ClientTest do
     end
 
     @tag core: true
-    test "zero version" do
+    test "zero version is rejected at config time, not sent to the server" do
       opts = [versions: ["0.0"]] ++ @opts
-      {:error, %Bolty.Error{code: :version_negotiation_error}} = Client.connect(opts)
+      assert {:error, %Bolty.Error{code: :unsupported_versions}} = Client.connect(opts)
     end
 
     @tag core: true
-    test "major version incompatible with the server" do
+    test "a version bolty doesn't implement is rejected at config time, not sent to the server" do
       opts = [versions: ["50.0"]] ++ @opts
-      {:error, %Bolty.Error{code: :version_negotiation_error}} = Client.connect(opts)
+      assert {:error, %Bolty.Error{code: :unsupported_versions}} = Client.connect(opts)
+    end
+
+    @tag core: true
+    test ":versions with only unsupported entries returns a clean error listing them" do
+      opts = [versions: ["3.0", "4.2"]] ++ @opts
+
+      assert {:error, %Bolty.Error{code: :unsupported_versions, bolt: %{message: message}}} =
+               Client.connect(opts)
+
+      assert message =~ "3.0"
+      assert message =~ "4.2"
     end
 
     @tag core: true

--- a/test/bolty/pack_stream_test.exs
+++ b/test/bolty/pack_stream_test.exs
@@ -7,7 +7,6 @@ defmodule Bolty.PackStreamTest do
   alias Bolty.PackStream
   alias Bolty.Policy
   alias Bolty.Types.{TimeWithTZOffset, DateTimeWithTZOffset, Point}
-  alias Bolty.TypesHelper
   alias Bolty.TestDerivationStruct
 
   @evolved %Policy{datetime: :evolved}
@@ -173,7 +172,7 @@ defmodule Bolty.PackStreamTest do
       # May 2016 Berlin is CEST (UTC+2). Evolved body carries the UTC instant —
       # so the seconds word drops by 7200 relative to legacy (0x57445670 local
       # → 0x57443A50 UTC). Nanoseconds and zone-id string are unchanged.
-      dt = TypesHelper.datetime_with_micro(~N[2016-05-24 13:26:08.654321], "Europe/Berlin")
+      dt = DateTime.from_naive!(~N[2016-05-24 13:26:08.654321], "Europe/Berlin")
 
       assert <<0xB3, 0x69, 0xCA, 0x57, 0x44, 0x3A, 0x50, 0xCA, 0x27, 0x0, 0x25, 0x68, 0x8D, 0x45,
                0x75, 0x72, 0x6F, 0x70, 0x65, 0x2F, 0x42, 0x65, 0x72, 0x6C, 0x69, 0x6E>> ==
@@ -483,66 +482,12 @@ defmodule Bolty.PackStreamTest do
                )
     end
 
-    test "Datetime with zone id" do
-      dt =
-        Bolty.TypesHelper.datetime_with_micro(~N[1998-03-18 06:25:12.123456], "Europe/Paris")
-
-      assert [dt] ==
-               PackStream.unpack!(
-                 {0x66,
-                  <<0xCA, 0x35, 0xF, 0x68, 0xC8, 0xCA, 0x7, 0x5B, 0xCA, 0x0, 0x8C, 0x45, 0x75,
-                    0x72, 0x6F, 0x70, 0x65, 0x2F, 0x50, 0x61, 0x72, 0x69, 0x73>>, 3}
-               )
-
-      dt =
-        Bolty.TypesHelper.datetime_with_micro(
-          ~N[2016-05-24 13:26:08.654321],
-          "Europe/Berlin"
-        )
-
-      assert [dt] ==
-               PackStream.unpack!(
-                 <<0xB3, 0x66, 0xCA, 0x57, 0x44, 0x56, 0x70, 0xCA, 0x27, 0x0, 0x25, 0x68, 0x8D,
-                   0x45, 0x75, 0x72, 0x6F, 0x70, 0x65, 0x2F, 0x42, 0x65, 0x72, 0x6C, 0x69, 0x6E>>
-               )
-    end
-
-    test "Datetime with zone offset" do
-      assert [
-               %DateTimeWithTZOffset{
-                 naive_datetime: ~N[1998-03-18 06:25:12.123456],
-                 timezone_offset: 7200
-               }
-             ] ==
-               PackStream.unpack!(
-                 {0x46,
-                  <<0xCA, 0x35, 0xF, 0x68, 0xC8, 0xCA, 0x7, 0x5B, 0xCA, 0x0, 0xC9, 0x1C, 0x20>>,
-                  3}
-               )
-
-      assert [
-               %DateTimeWithTZOffset{
-                 naive_datetime: ~N[2016-05-24 13:26:08.654321],
-                 timezone_offset: 7200
-               }
-             ] =
-               PackStream.unpack!(
-                 <<0xB3, 0x46, 0xCA, 0x57, 0x44, 0x56, 0x70, 0xCA, 0x27, 0x0, 0x25, 0x68, 0xC9,
-                   0x1C, 0x20>>
-               )
-    end
-
     test "Datetime with zone id — evolved (0x69) decodes UTC-instant seconds" do
       # Symmetric with the evolved packer: the wire carries UTC seconds
       # (0x57443A50 = 1_464_089_168) plus the zone id; the unpacker reconstructs
       # via DateTime.from_unix + DateTime.shift_zone, so the local wall clock
-      # lands at 13:26:08 CEST — the same DateTime a legacy 0x66 of the same
-      # local wall clock would produce.
-      dt =
-        Bolty.TypesHelper.datetime_with_micro(
-          ~N[2016-05-24 13:26:08.654321],
-          "Europe/Berlin"
-        )
+      # lands at 13:26:08 CEST.
+      dt = DateTime.from_naive!(~N[2016-05-24 13:26:08.654321], "Europe/Berlin")
 
       assert [dt] ==
                PackStream.unpack!(
@@ -568,11 +513,7 @@ defmodule Bolty.PackStreamTest do
     end
 
     test "Datetime zone-id/zone-offset — evolved round-trip" do
-      dt_zone_id =
-        Bolty.TypesHelper.datetime_with_micro(
-          ~N[2016-05-24 13:26:08.654321],
-          "Europe/Berlin"
-        )
+      dt_zone_id = DateTime.from_naive!(~N[2016-05-24 13:26:08.654321], "Europe/Berlin")
 
       evolved_bytes = :erlang.iolist_to_binary(PackStream.pack!(dt_zone_id, @evolved))
       assert [dt_zone_id] == PackStream.unpack!(evolved_bytes)

--- a/test/bolty/types_helper_test.exs
+++ b/test/bolty/types_helper_test.exs
@@ -28,33 +28,6 @@ defmodule Bolty.TypesHelperTest do
     end
   end
 
-  describe "datetime_with_micro/2:" do
-    test "Successful with valid data" do
-      expected = %DateTime{
-        calendar: Calendar.ISO,
-        day: 1,
-        hour: 23,
-        microsecond: {0, 0},
-        minute: 0,
-        month: 1,
-        second: 7,
-        std_offset: 0,
-        time_zone: "Europe/Paris",
-        utc_offset: 3600,
-        year: 2000,
-        zone_abbr: "CET"
-      }
-
-      assert ^expected = TypesHelper.datetime_with_micro(~N[2000-01-01 23:00:07], "Europe/Paris")
-    end
-
-    test "Fails with invalid timezone" do
-      assert_raise ArgumentError, fn ->
-        TypesHelper.datetime_with_micro(~N[2000-01-01 23:00:07], "Invalid")
-      end
-    end
-  end
-
   describe "formated-time_offset/1" do
     test "Valid positive offset" do
       assert "+01:03" == TypesHelper.formated_time_offset(3783)


### PR DESCRIPTION
## Summary

Closes #104. Two related commits, both about bolty's Bolt-version handling:

**1. Remove unreachable Bolt <5.0 legacy datetime code (#104)**

bolty only ever negotiates Bolt 5.0+ (`@available_bolt_versions` starts at `{5, 0}`; `Policy.Resolver.put_datetime` sets `:evolved` for every `>= {5, 0}` connection), so the legacy pre-5.0 datetime wire format was dead:
- `unpacker.ex`: drop the legacy zone-id (`0x66`) and zone-offset (`0x46`) decode clauses.
- `markers.ex`: drop the associated legacy signature/struct-size constants.
- `TypesHelper.datetime_with_micro/2` removed — it was solely the legacy zone-id clause's helper, otherwise just a `DateTime.from_naive!/2` wrapper; call sites in tests now use `DateTime.from_naive!/2` directly.
- `Policy.datetime` type narrowed from `:legacy | :evolved` to `:evolved` only (the packer never actually had a `:legacy` encode clause to begin with).
- `Versions.coalesce/2` simplified, dropping the unreachable pre-4.3 range-merge branches.
- Tests covering the removed legacy decode paths and `datetime_with_micro/2` are removed with the code they exercised.

The one item from #104 flagged as a judgment call — the per-message `>= {3,0}`/`>= {4,0}` version guards on individual `encode/_` clauses — is intentionally left as-is; those document each message's protocol-level minimum and give a clean failure if the floor ever changes, unlike the datetime dialect code which had no such value.

**2. Reject `:versions` bolty doesn't implement at config time**

Found while reviewing the above: `Client.Config.get_versions/1` never validated a user-supplied `:versions` opt against `Versions.available_versions()` — an unsupported version would flow straight into the handshake bytes. If a server ever accepted it, bolty would proceed past handshake speaking a wire dialect its own message code doesn't implement, and fail confusingly deep in encode/decode instead of cleanly at connect — a sharper risk now that the legacy datetime code above is gone.

`get_versions/1` now filters requested versions against `Versions.available_versions()`:
- Unsupported entries are dropped with a `Logger.warning`, as long as at least one requested version is actually supported.
- If none are supported, `Config.new/1` returns `{:error, %Bolty.Error{code: :unsupported_versions}}` immediately, before any socket activity — consistent with how `:missing_username` already fails fast.

This changes two existing tests' expected error (`:version_negotiation_error` at handshake time → `:unsupported_versions` at config time) and adds coverage for the warn-and-drop path and the all-unsupported hard-error path.

## Test plan

- [x] Full suite (no DB): 231 tests pass.
- [x] Against the live local Neo4j 5.26.x server (port 7687), `BOLT_VERSIONS=5.8`: 344 tests pass.
- [x] Against the same server pinned to `BOLT_VERSIONS=5.3` (exercises the real handshake for the mixed supported/unsupported `:versions` warning test): 44 tests pass.
- [x] `mix credo`, `mix format --check-formatted`, `mix dialyzer` all clean.