### PR TITLE
fix: close error-surface raise-through gaps + spec/type cleanup (#110, #111)

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,6 +1,4 @@
 # SPDX-FileCopyrightText: 2024 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
-[
-  ~r/__impl__.*does\ not\ exist\./
-]
+[]

--- a/lib/bolty.ex
+++ b/lib/bolty.ex
@@ -56,7 +56,7 @@ defmodule Bolty do
           {:uri, String.t()}
           | {:hostname, String.t()}
           | {:port, :inet.port_number()}
-          | {:scheme, :inet.port_number()}
+          | {:scheme, String.t()}
           | {:versions, list(String.t() | float())}
           | {:auth, basic_auth()}
           | {:user_agent, String.t()}
@@ -135,7 +135,7 @@ defmodule Bolty do
 
   * `:pool_size` - The size of the pool
   """
-  @spec start_link([start_option()]) :: {:ok, pid()} | {:error, Bolty.Error.t()}
+  @spec start_link([start_option()]) :: GenServer.on_start()
   def start_link(options) do
     DBConnection.start_link(Bolty.Connection, options)
   end

--- a/lib/bolty.ex
+++ b/lib/bolty.ex
@@ -274,8 +274,10 @@ defmodule Bolty do
           policy: Bolty.Policy.t()
         }
   def connection_info(conn) do
-    {:ok, _, info} = DBConnection.prepare_execute(conn, %Bolty.ConnectionInfo{}, %{})
-    info
+    case DBConnection.prepare_execute(conn, %Bolty.ConnectionInfo{}, %{}) do
+      {:ok, _query, info} -> info
+      {:error, error} -> raise error
+    end
   end
 
   # Wrap the round-trip in a `[:bolty, :query]` telemetry span so operators get

--- a/lib/bolty/client.ex
+++ b/lib/bolty/client.ex
@@ -158,23 +158,39 @@ defmodule Bolty.Client do
           {:ok, Versions.latest_versions()}
 
         versions ->
-          {parsed, deprecated_float?} =
-            Enum.map_reduce(versions, false, fn version, dep? ->
-              {canonical, float?} = Versions.parse(version)
-              {canonical, dep? or float?}
-            end)
-
-          if deprecated_float? do
-            require Logger
-
-            Logger.warning(
-              "bolty: passing float Bolt versions to :versions is deprecated and will be " <>
-                "removed; use strings like \"5.4\" (a float can't distinguish 5.10 from 5.1)."
-            )
-          end
-
-          reject_unsupported_versions(versions, parsed)
+          parse_versions(versions)
       end
+    end
+
+    # Versions.parse/1 raises on a malformed entry (e.g. "abc" -> ArgumentError,
+    # "5" or "5.4.3" -> MatchError, an unrecognised shape like an atom or map ->
+    # FunctionClauseError) — none of which are documented, so left uncaught they
+    # crash the connect callback instead of returning the {:error, %Bolty.Error{}}
+    # this module otherwise guarantees (see :missing_username, :unsupported_versions).
+    defp parse_versions(versions) do
+      {parsed, deprecated_float?} =
+        Enum.map_reduce(versions, false, fn version, dep? ->
+          {canonical, float?} = Versions.parse(version)
+          {canonical, dep? or float?}
+        end)
+
+      if deprecated_float? do
+        require Logger
+
+        Logger.warning(
+          "bolty: passing float Bolt versions to :versions is deprecated and will be " <>
+            "removed; use strings like \"5.4\" (a float can't distinguish 5.10 from 5.1)."
+        )
+      end
+
+      reject_unsupported_versions(versions, parsed)
+    rescue
+      e ->
+        {:error,
+         Bolty.Error.wrap(Bolty.Client, %{
+           code: :invalid_versions,
+           message: "invalid :versions #{inspect(versions)}: #{Exception.message(e)}"
+         })}
     end
 
     # bolty only ever negotiates versions it actually implements — a version

--- a/lib/bolty/error.ex
+++ b/lib/bolty/error.ex
@@ -42,6 +42,20 @@ defmodule Bolty.Error do
   def wrap(module, bolt_error) when is_map(bolt_error),
     do: %__MODULE__{module: module, code: bolt_error.code |> to_atom(), bolt: bolt_error}
 
+  # Mirrors Client.wrap_connect_error/1's tuple handling so any caller passing a
+  # raw tuple reason (e.g. a post-connect :ssl recv error during HELLO/LOGON)
+  # gets a clean %Bolty.Error{} instead of hitting this module's is_atom/
+  # is_binary/is_map guards and raising a FunctionClauseError.
+  @spec wrap(module(), {:tls_alert, {atom(), any()}}) :: t()
+  def wrap(module, {:tls_alert, {alert, description}}) do
+    wrap(module, %{code: :tls_alert, message: "#{alert}: #{description}"})
+  end
+
+  @spec wrap(module(), tuple()) :: t()
+  def wrap(module, reason) when is_tuple(reason) do
+    wrap(module, %{code: :connect_error, message: inspect(reason)})
+  end
+
   @spec wrap(any(), any(), any()) :: t()
   def wrap(module, code, packstream),
     do: %__MODULE__{module: module, code: code, packstream: packstream}

--- a/lib/bolty/types.ex
+++ b/lib/bolty/types.ex
@@ -92,6 +92,9 @@ defmodule Bolty.Types do
 
     @type t :: %__MODULE__{
             id: integer,
+            start: integer,
+            end: integer,
+            type: String.t(),
             properties: map,
             element_id: String.t(),
             start_node_element_id: String.t(),

--- a/test/bolty/client_test.exs
+++ b/test/bolty/client_test.exs
@@ -184,6 +184,16 @@ defmodule Bolty.ClientTest do
       assert message =~ "{3, 0..2}"
     end
 
+    test "malformed :versions entries return a clean error instead of raising (#110)" do
+      for bad <- ["abc", "5", "5.4.3", :atom, %{}, [1, 2]] do
+        assert {:error, %Bolty.Error{code: :invalid_versions, bolt: %{message: message}}} =
+                 Client.Config.new(auth: [username: "u"], versions: [bad]),
+               "expected #{inspect(bad)} to return a clean error, not raise"
+
+        assert message =~ inspect(bad)
+      end
+    end
+
     test "maps schemes to the correct TLS verification intent" do
       base_opts = [
         auth: [username: "usertests"]

--- a/test/bolty/error_test.exs
+++ b/test/bolty/error_test.exs
@@ -37,6 +37,26 @@ defmodule Bolty.ErrorTest do
     end
   end
 
+  describe "Error.wrap/2 tuple handling (#110)" do
+    @tag :core
+    test "a {:tls_alert, ...} reason is wrapped, not left to raise on a bare tuple" do
+      error =
+        Error.wrap(Bolty.Client, {:tls_alert, {:certificate_expired, ~c"certificate expired"}})
+
+      assert %Error{code: :tls_alert, bolt: %{message: message}} = error
+      assert message =~ "certificate_expired"
+      assert message =~ "certificate expired"
+    end
+
+    @tag :core
+    test "any other tuple reason is wrapped with the raw reason preserved for diagnosis" do
+      error = Error.wrap(Bolty.Client, {:some_reason, :nested})
+
+      assert %Error{code: :connect_error, bolt: %{message: message}} = error
+      assert message =~ "some_reason"
+    end
+  end
+
   describe "Error.to_atom/1 status-code mapping (#54)" do
     @tag :core
     test "maps the curated Neo4j status codes to stable atoms" do


### PR DESCRIPTION
## Summary

Closes #110 and closes #111 — bundled per the issues' own suggestion, as two commits.

**#110 — remaining error-surface raise-through gaps:**
- `Client.Config.get_versions/1` could still raise on a malformed `:versions` entry (`Versions.parse/1` raises `ArgumentError` on `"abc"`, `MatchError` on `"5"`/`"5.4.3"`, `FunctionClauseError` on an unrecognised shape like an atom or map) instead of returning `{:error, %Bolty.Error{code: :invalid_versions}}`.
- `Bolty.connection_info/1` hard-matched `{:ok, _, info} =`, so a pool error surfaced as an opaque `MatchError` instead of the underlying error — now dispatches the same `{:ok,_,_}`/`{:error,_}` shape `do_query/4` already handles elsewhere in this module, raising the real error.
- `Bolty.Error.wrap/2` had no tuple clause, so a raw tuple reason (e.g. `{:tls_alert, ...}` from a post-connect recv during HELLO/LOGON) hit the `is_atom`/`is_binary`/`is_map` guards and raised a `FunctionClauseError`. Mirrors `Client.wrap_connect_error/1`'s existing tuple handling directly in `Error.wrap/2`, so every caller benefits — including `get_chunk_size`/`get_chunk` in `client.ex`, which call `Error.wrap/2` with a raw reason directly and needed no separate change.

**#111 — misc @spec/type nits:**
- `{:scheme, :inet.port_number()}` → `{:scheme, String.t()}` (copy-paste from the adjacent `:port` line).
- `start_link/1`'s `@spec` claimed `{:error, Bolty.Error.t()}`, but DBConnection connects asynchronously — a connect-time `%Bolty.Error{}` never comes back through `start_link/1`; its actual error shape is `GenServer.on_start()`'s.
- `Relationship`'s `@type t` omitted the `start`/`end`/`type` fields the struct actually has.
- Removed the one `.dialyzer_ignore.exs` entry dialyzer itself already reported as unneeded (confirmed: `Unnecessary Skips: 1` → `0`).

None of the #111 items change runtime behaviour.

## Test plan

- [x] New tests for malformed `:versions` (all raise-prone shapes: `"abc"`, `"5"`, `"5.4.3"`, an atom, a map, a list) and `Error.wrap/2` tuple handling (`:tls_alert` and generic tuple reasons).
- [x] `connection_info/1`'s fix is verified by inspection (identical `{:ok,_,_}`/`{:error,_}` dispatch pattern already used by `do_query/4` in the same module) rather than a forced repro — a live `DBConnection.ConnectionError` return (as opposed to a process `exit`, which I confirmed does *not* go through this code path) proved impractical to force deterministically without flakiness.
- [x] Full suite (no DB): 233 pass. Against the live local Neo4j 5.26.x server (`BOLT_VERSIONS=5.8`): 351 pass.
- [x] `mix credo`, `mix format --check-formatted`, `mix dialyzer` (confirms `Unnecessary Skips: 0`) all clean.