### PR TITLE
fix: remove dead :ssl option and warn on its use (#107)

### DIFF
--- a/lib/bolty.ex
+++ b/lib/bolty.ex
@@ -62,7 +62,6 @@ defmodule Bolty do
           | {:user_agent, String.t()}
           | {:notifications_minimum_severity, String.t()}
           | {:notifications_disabled_categories, list(String.t())}
-          | {:ssl, boolean()}
           | {:ssl_opts, [:ssl.tls_client_option()]}
           | {:connect_timeout, timeout()}
           | {:recv_timeout, timeout()}
@@ -89,7 +88,10 @@ defmodule Bolty do
 
   * `:port` - Server port (default: `7687`)
 
-  * `:scheme` - Is one among neo4j, neo4j+s, neo4j+ssc, bolt, bolt+s, bolt+ssc (default: bolt+s).
+  * `:scheme` - Is one among neo4j, neo4j+s, neo4j+ssc, bolt, bolt+s, bolt+ssc
+   (default: bolt+s). TLS is derived entirely from this: `bolt`/`neo4j` is
+   plaintext, `+s` is full certificate verification against the OS trust
+   store, `+ssc` is encrypted but trust-all (self-signed certs).
 
   * `:versions` - List of Bolt versions to offer during negotiation, as strings
    (`["5.4", "6.0"]`) or `{major, minor..minor}` range tuples (`[{5, 6..8}]`).
@@ -121,9 +123,11 @@ defmodule Bolty do
       to `query/4`; set to `:infinity` for queries that may compute for a long
       time before returning any data.
 
-  * `:ssl` - Set to `true` if SSL should be used (default: `true`)
-
-  * `:ssl_opts` - A list of SSL options, see `:ssl.connect/2` (default: `[verify: :verify_none]`)
+  * `:ssl_opts` - A list of `:ssl.connect/2` options, merged *over* the strict,
+   secure-by-default TLS options bolty derives from `:scheme` (default: `[]`).
+   An explicit `verify:`/`cacertfile:`/`cacerts:` here always overrides the
+   scheme-derived default. Only applies when `:scheme` enables TLS (`+s` or
+   `+ssc`); ignored for plain `bolt`/`neo4j`.
 
   The given options are passed down to DBConnection, some of the most commonly used ones are
    documented below:

--- a/lib/bolty/client.ex
+++ b/lib/bolty/client.ex
@@ -66,6 +66,8 @@ defmodule Bolty.Client do
       {username, password} = get_user_and_pass(opts)
       {scheme, ssl?, tls_verify, ssl_opts} = get_scheme_and_ssl_opts(opts)
 
+      warn_if_legacy_ssl_option(opts)
+
       with :ok <- validate_username(username),
            {:ok, versions} <- get_versions(opts) do
         {:ok,
@@ -99,6 +101,25 @@ defmodule Bolty.Client do
     end
 
     defp validate_username(_username), do: :ok
+
+    # :ssl (a boolean) was the pre-P0-1 TLS toggle; TLS intent is now derived
+    # entirely from :scheme, and nothing reads :ssl anymore. Any other
+    # unrecognised option is silently ignored (see #107 discussion — general
+    # unknown-option validation is a separate, bigger concern), but :ssl gets
+    # a targeted warning since it's the one option we know used to work and
+    # whose silent removal could leave a caller believing TLS is configured
+    # when it is not.
+    defp warn_if_legacy_ssl_option(opts) do
+      if Keyword.has_key?(opts, :ssl) do
+        require Logger
+
+        Logger.warning(
+          "bolty: :ssl is no longer a supported option and is ignored — TLS is derived " <>
+            "entirely from :scheme (bolt/neo4j = plaintext, +s = verified TLS, +ssc = " <>
+            "self-signed TLS); remove :ssl from your connection options."
+        )
+      end
+    end
 
     # Maps the connection scheme to a TLS *intent*, not materialised ssl options:
     # the strict defaults (incl. SNI, which needs the hostname) are built at

--- a/test/bolty/client_config_test.exs
+++ b/test/bolty/client_config_test.exs
@@ -214,6 +214,36 @@ defmodule Bolty.ClientConfigTest do
                Client.Config.new(opts6)
     end
 
+    test "a stray :ssl option has no effect on TLS but logs a warning (#107)" do
+      import ExUnit.CaptureLog
+
+      # The old :ssl boolean was removed as dead code; TLS derives entirely
+      # from :scheme. Confirms a caller can't silently get plaintext by
+      # setting ssl: true alongside a plaintext scheme (or vice versa) without
+      # at least being warned — the key still has no functional effect, but
+      # its presence is no longer silent.
+      opts = [auth: [username: "usertests"], scheme: "bolt", ssl: true]
+
+      log =
+        capture_log(fn ->
+          assert {:ok, %Client.Config{scheme: "bolt", ssl?: false, tls_verify: :none}} =
+                   Client.Config.new(opts)
+        end)
+
+      assert log =~ ":ssl is no longer a supported option"
+    end
+
+    test "no :ssl key means no warning" do
+      import ExUnit.CaptureLog
+
+      log =
+        capture_log(fn ->
+          {:ok, _config} = Client.Config.new(auth: [username: "usertests"], scheme: "bolt")
+        end)
+
+      refute log =~ ":ssl"
+    end
+
     test "preserves user-supplied :ssl_opts verbatim (no override at config time)" do
       opts = [
         auth: [username: "usertests"],

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -77,8 +77,7 @@ defmodule Bolty.TestHelper do
       ssl_opts: ssl_opts(),
       pool_size: 1,
       prefix: :default,
-      scheme: "bolt",
-      ssl: false
+      scheme: "bolt"
     ]
     |> with_env_overrides()
   end
@@ -91,8 +90,7 @@ defmodule Bolty.TestHelper do
       pool_size: 1,
       max_overflow: 3,
       prefix: :default,
-      scheme: "bolt",
-      ssl: false
+      scheme: "bolt"
     ]
     |> with_env_overrides()
   end


### PR DESCRIPTION
## Summary

Closes #107.

Since the P0-1 TLS fix, `:scheme` is the sole source of TLS intent (`Client.Config.get_scheme_and_ssl_opts/1`) — nothing reads a separate `:ssl` boolean. But `lib/bolty.ex` still typed and documented one with its pre-fix semantics (`"default: true"`, `ssl_opts` default of `[verify: :verify_none]`), so a caller following the docs could set `ssl: true` alongside `scheme: "bolt"` and silently get plaintext.

**Decision (locked on #107):** remove `{:ssl, boolean()}` from `start_option()` and its `@doc` — `:scheme` is already authoritative everywhere else, and `:ssl` is a leftover from before the scheme-based TLS redesign, not a feature needing its own validation logic.

**Revised after discussion:** silently ignoring the key wasn't good enough — bolty already warns (rather than silently accepting or rejecting) on the other deprecated option shape in this exact function, a float `:versions` entry, so `:ssl` gets the same treatment. `Config.new/1` now logs a targeted `Logger.warning` whenever `:ssl` is present, regardless of its value, pointing the caller at `:scheme`. This is intentionally narrow to the one option known to have been removed — general unknown-option validation (should bolty reject *any* unrecognised key, e.g. a typo like `hostnam:`?) is a separate, bigger question that also needs an allowlist of legitimate DBConnection pass-through options to avoid false rejections; tracked for later, not folded into this PR.

Also:
- Fixed the adjacent `:ssl_opts` doc, which still stated the stale pre-P0-1 default — documented it as merging over the scheme-derived strict defaults instead.
- Expanded the `:scheme` doc to state what each variant does (TLS derives entirely from it now).
- Removed the dead `ssl: false` from `test/test_helper.exs`'s two opts builders (`scheme: "bolt"` already implies no TLS).

## Test plan

- [x] New test confirms a stray `ssl: true` alongside `scheme: "bolt"` has no effect on the resulting TLS config, but does log the warning.
- [x] New test confirms no warning when `:ssl` is absent.
- [x] Full suite (no DB): 255 pass. Against the live local Neo4j 5.26.x server (`BOLT_VERSIONS=5.8`): 353 pass.
- [x] `mix credo`, `mix format --check-formatted`, `mix dialyzer` all clean.