### PR TITLE
feat: validate start_link/1 options against an allowlist (#121)

### DIFF
--- a/lib/bolty/client.ex
+++ b/lib/bolty/client.ex
@@ -34,6 +34,20 @@ defmodule Bolty.Client do
     @default_timeout 15_000
     @default_port 7687
 
+    # Mirrors the `start_option()` typespec in lib/bolty.ex.
+    @bolty_option_keys ~w(
+      uri hostname port scheme versions auth user_agent
+      notifications_minimum_severity notifications_disabled_categories
+      ssl_opts connect_timeout recv_timeout socket_options
+    )a
+
+    # DBConnection.ConnectionPool.Pool prepends `pool_index: id` to every
+    # pooled connection's opts before calling `conn_mod.connect/1` — it's
+    # never something a caller passes to `start_link/1` themselves (and so
+    # isn't in `available_start_options/0`), but it *does* show up here since
+    # Config.new/1 runs inside that connect callback.
+    @dbconnection_internal_keys ~w(pool_index)a
+
     # Redact the password so a failed-connect crash report (DBConnection includes
     # state/opts) can't leak it to logs.
     @derive {Inspect, except: [:password]}
@@ -55,41 +69,102 @@ defmodule Bolty.Client do
     @doc """
     Builds a `%Config{}` from connection options.
 
-    Returns `{:ok, config}`, or `{:error, %Bolty.Error{}}` when a required field
-    (currently `:username`) is missing, or when `:versions` contains no version
-    bolty actually implements — either way the caller surfaces that cleanly
-    rather than raising (or silently misbehaving) inside DBConnection's connect
-    callback.
+    Returns `{:ok, config}`, or `{:error, %Bolty.Error{}}` when an unrecognised
+    option key is passed, when a required field (currently `:username`) is
+    missing, or when `:versions` contains no version bolty actually
+    implements — either way the caller surfaces that cleanly rather than
+    raising (or silently misbehaving) inside DBConnection's connect callback.
     """
     def new(opts) do
-      {hostname, port} = get_hostname_and_port(opts)
-      {username, password} = get_user_and_pass(opts)
-      {scheme, ssl?, tls_verify, ssl_opts} = get_scheme_and_ssl_opts(opts)
+      with :ok <- validate_options(opts) do
+        {hostname, port} = get_hostname_and_port(opts)
+        {username, password} = get_user_and_pass(opts)
+        {scheme, ssl?, tls_verify, ssl_opts} = get_scheme_and_ssl_opts(opts)
 
-      warn_if_legacy_ssl_option(opts)
-
-      with :ok <- validate_username(username),
-           {:ok, versions} <- get_versions(opts) do
-        {:ok,
-         %__MODULE__{
-           hostname: hostname,
-           port: port,
-           scheme: scheme,
-           username: username,
-           password: password,
-           connect_timeout: Keyword.get(opts, :connect_timeout, @default_timeout),
-           recv_timeout: Keyword.get(opts, :recv_timeout, @default_timeout),
-           socket_options:
-             Keyword.merge(
-               [mode: :binary, packet: :raw, active: false],
-               opts[:socket_options] || []
-             ),
-           versions: versions,
-           ssl?: ssl?,
-           tls_verify: tls_verify,
-           ssl_opts: ssl_opts
-         }}
+        with :ok <- validate_username(username),
+             {:ok, versions} <- get_versions(opts) do
+          {:ok,
+           %__MODULE__{
+             hostname: hostname,
+             port: port,
+             scheme: scheme,
+             username: username,
+             password: password,
+             connect_timeout: Keyword.get(opts, :connect_timeout, @default_timeout),
+             recv_timeout: Keyword.get(opts, :recv_timeout, @default_timeout),
+             socket_options:
+               Keyword.merge(
+                 [mode: :binary, packet: :raw, active: false],
+                 opts[:socket_options] || []
+               ),
+             versions: versions,
+             ssl?: ssl?,
+             tls_verify: tls_verify,
+             ssl_opts: ssl_opts
+           }}
+        end
       end
+    end
+
+    # Rejects any option key that is neither one of bolty's own (mirrored in
+    # @bolty_option_keys above) nor a key DBConnection itself understands.
+    # DBConnection.available_start_options/0 is queried live rather than
+    # hand-copied, so this stays in sync with whatever db_connection version
+    # is actually installed instead of drifting on a version bump (#121).
+    # Without this, a typo like `hostnam: "..."` silently falls back to the
+    # `"localhost"` default with zero signal that anything is wrong.
+    defp validate_options(opts) do
+      warn_on_conflicting_duplicates(opts)
+
+      # A plain membership check rather than `Keyword.validate/2`: that
+      # function treats each valid key as consumable only once, so a
+      # legitimately-repeated key (e.g. `[pool_size: 1] ++ TestHelper.opts()`,
+      # a common "override by prepending" idiom, where `pool_size` then
+      # appears twice) is flagged as invalid on its second occurrence.
+      valid_keys =
+        MapSet.new(
+          @bolty_option_keys ++
+            @dbconnection_internal_keys ++ DBConnection.available_start_options()
+        )
+
+      invalid_keys =
+        opts |> Keyword.keys() |> Enum.uniq() |> Enum.reject(&MapSet.member?(valid_keys, &1))
+
+      case invalid_keys do
+        [] ->
+          :ok
+
+        invalid_keys ->
+          {:error,
+           Bolty.Error.wrap(Bolty.Client, %{
+             code: :invalid_option,
+             message:
+               "unrecognised option(s) #{inspect(invalid_keys)} — check for a typo; see " <>
+                 "Bolty.start_option() for the supported keys"
+           })}
+      end
+    end
+
+    # A key repeated with the *same* value every time (e.g. the deliberate
+    # `[pool_size: 1] ++ base_opts` override idiom, when base_opts already
+    # carries that same value) is inert and stays silent — `Keyword.get/3`
+    # takes the first occurrence either way. A key repeated with *different*
+    # values is ambiguous enough to be worth a warning: it's as likely to be a
+    # copy-paste mistake as a deliberate override, and either way the caller
+    # should know only the first value is actually used.
+    defp warn_on_conflicting_duplicates(opts) do
+      opts
+      |> Enum.group_by(fn {key, _value} -> key end, fn {_key, value} -> value end)
+      |> Enum.each(fn {key, values} ->
+        if values |> Enum.uniq() |> length() > 1 do
+          require Logger
+
+          Logger.warning(
+            "bolty: option :#{key} was passed multiple times with different values " <>
+              "#{inspect(values)} — the first occurrence wins; remove the duplicate if unintended"
+          )
+        end
+      end)
     end
 
     defp validate_username(nil) do
@@ -101,25 +176,6 @@ defmodule Bolty.Client do
     end
 
     defp validate_username(_username), do: :ok
-
-    # :ssl (a boolean) was the pre-P0-1 TLS toggle; TLS intent is now derived
-    # entirely from :scheme, and nothing reads :ssl anymore. Any other
-    # unrecognised option is silently ignored (see #107 discussion — general
-    # unknown-option validation is a separate, bigger concern), but :ssl gets
-    # a targeted warning since it's the one option we know used to work and
-    # whose silent removal could leave a caller believing TLS is configured
-    # when it is not.
-    defp warn_if_legacy_ssl_option(opts) do
-      if Keyword.has_key?(opts, :ssl) do
-        require Logger
-
-        Logger.warning(
-          "bolty: :ssl is no longer a supported option and is ignored — TLS is derived " <>
-            "entirely from :scheme (bolt/neo4j = plaintext, +s = verified TLS, +ssc = " <>
-            "self-signed TLS); remove :ssl from your connection options."
-        )
-      end
-    end
 
     # Maps the connection scheme to a TLS *intent*, not materialised ssl options:
     # the strict defaults (incl. SNI, which needs the hostname) are built at

--- a/test/bolty/client_config_test.exs
+++ b/test/bolty/client_config_test.exs
@@ -83,6 +83,67 @@ defmodule Bolty.ClientConfigTest do
                Client.Config.new(hostname: "localhost")
     end
 
+    test "an unrecognised option key returns a clean error instead of a silent default (#121)" do
+      assert {:error, %Bolty.Error{code: :invalid_option, bolt: %{message: message}}} =
+               Client.Config.new(hostnam: "localhost", auth: [username: "u"])
+
+      assert message =~ "hostnam"
+    end
+
+    test "every bolty start_option() key is accepted" do
+      opts = [
+        uri: "bolt://localhost:7687",
+        hostname: "localhost",
+        port: 7687,
+        scheme: "bolt",
+        versions: ["5.4"],
+        auth: [username: "u", password: "p"],
+        user_agent: "my_app/1.0",
+        notifications_minimum_severity: "WARNING",
+        notifications_disabled_categories: ["HINT"],
+        ssl_opts: [],
+        connect_timeout: 1_000,
+        recv_timeout: 1_000,
+        socket_options: []
+      ]
+
+      assert {:ok, %Client.Config{}} = Client.Config.new(opts)
+    end
+
+    test "DBConnection's own start options (e.g. :pool_size, :name) are accepted" do
+      assert {:ok, %Client.Config{}} =
+               Client.Config.new(
+                 auth: [username: "u"],
+                 pool_size: 5,
+                 name: :my_bolty_pool,
+                 after_connect: fn _ -> :ok end
+               )
+    end
+
+    test "a key repeated with the same value (the override-by-prepending idiom) is silent" do
+      import ExUnit.CaptureLog
+
+      log =
+        capture_log(fn ->
+          assert {:ok, %Client.Config{port: 7687}} =
+                   Client.Config.new(auth: [username: "u"], port: 7687, port: 7687)
+        end)
+
+      refute log =~ "multiple times"
+    end
+
+    test "a key repeated with conflicting values logs a warning, first occurrence wins" do
+      import ExUnit.CaptureLog
+
+      log =
+        capture_log(fn ->
+          assert {:ok, %Client.Config{port: 7687}} =
+                   Client.Config.new(auth: [username: "u"], port: 7687, port: 9999)
+        end)
+
+      assert log =~ "option :port was passed multiple times with different values"
+    end
+
     test "the password is redacted when the config is inspected" do
       {:ok, config} = Client.Config.new(auth: [username: "u", password: "s3cret"])
       refute inspect(config) =~ "s3cret"
@@ -214,34 +275,19 @@ defmodule Bolty.ClientConfigTest do
                Client.Config.new(opts6)
     end
 
-    test "a stray :ssl option has no effect on TLS but logs a warning (#107)" do
-      import ExUnit.CaptureLog
-
+    test "a stray :ssl option is rejected as an unrecognised option (#107, #121)" do
       # The old :ssl boolean was removed as dead code; TLS derives entirely
-      # from :scheme. Confirms a caller can't silently get plaintext by
-      # setting ssl: true alongside a plaintext scheme (or vice versa) without
-      # at least being warned — the key still has no functional effect, but
-      # its presence is no longer silent.
+      # from :scheme. It used to get a targeted warn-only exception carved out
+      # of the general unknown-option handling (#107); now that #121 added
+      # general unknown-option validation, :ssl no longer needs (or gets) that
+      # special case — it's rejected the same way any other unrecognised key
+      # is, rather than being silently accepted with just a log line.
       opts = [auth: [username: "usertests"], scheme: "bolt", ssl: true]
 
-      log =
-        capture_log(fn ->
-          assert {:ok, %Client.Config{scheme: "bolt", ssl?: false, tls_verify: :none}} =
-                   Client.Config.new(opts)
-        end)
+      assert {:error, %Bolty.Error{code: :invalid_option, bolt: %{message: message}}} =
+               Client.Config.new(opts)
 
-      assert log =~ ":ssl is no longer a supported option"
-    end
-
-    test "no :ssl key means no warning" do
-      import ExUnit.CaptureLog
-
-      log =
-        capture_log(fn ->
-          {:ok, _config} = Client.Config.new(auth: [username: "usertests"], scheme: "bolt")
-        end)
-
-      refute log =~ ":ssl"
+      assert message =~ "ssl"
     end
 
     test "preserves user-supplied :ssl_opts verbatim (no override at config time)" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -76,7 +76,6 @@ defmodule Bolty.TestHelper do
       user_agent: "boltyTest/1",
       ssl_opts: ssl_opts(),
       pool_size: 1,
-      prefix: :default,
       scheme: "bolt"
     ]
     |> with_env_overrides()
@@ -88,8 +87,6 @@ defmodule Bolty.TestHelper do
       user_agent: "boltyTest/1",
       ssl_opts: ssl_opts(),
       pool_size: 1,
-      max_overflow: 3,
-      prefix: :default,
       scheme: "bolt"
     ]
     |> with_env_overrides()

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -278,6 +278,7 @@ To add a dimension: add the field to `Bolty.Policy`, extend `Bolty.Policy.Resolv
 - `@error_map` only covers four Neo bolt errors; everything else collapses to `:unknown`. Extend when you need finer-grained handling.
 - `format_param/1` at the top level only rewrites `Point`. Temporal-with-offset structs pass through as-is; call their own `format_param/1` if you need Cypher-ready strings.
 - A missing `:username` returns `{:error, %Bolty.Error{code: :missing_username}}` from the connect path (it no longer raises). (The old `BOLT_USER`/`BOLT_PWD`/`BOLT_HOST`/`BOLT_TCP_PORT`/`BOLT_VERSIONS` env-var config was removed in 0.3.0 — pass explicit options.)
+- `start_link/1` options are validated against an allowlist (bolty's own `start_option()` keys plus whatever `DBConnection.available_start_options/0` reports for the installed `db_connection` version); an unrecognised key (e.g. a typo like `hostnam: "..."`, or the removed pre-P0-1 `:ssl` boolean — TLS is derived entirely from `:scheme` now) returns `{:error, %Bolty.Error{code: :invalid_option}}` instead of silently falling back to a default.
 
 ## 16. Commit format and changelog
 


### PR DESCRIPTION
## Summary

`Config.new/1` now rejects any option key that isn't one of bolty's own `start_option()` keys, a key `DBConnection.available_start_options/0` reports for the installed `db_connection` version, or `:pool_index` (an internal key `DBConnection`'s pool prepends before calling `connect/1`). An unrecognised key — e.g. a typo like `hostnam: "..."` — now returns `{:error, %Bolty.Error{code: :invalid_option}}` instead of silently falling back to a default.

`available_start_options/0` is queried live rather than hand-copied, so the allowlist stays in sync with whatever `db_connection` version is actually installed instead of drifting on a version bump — the coupling concern originally raised in #121 turned out to be a non-issue once that function was found.

## Relationship to #107

#107 gave `:ssl` (the removed pre-P0-1 TLS toggle) a *targeted* warn-only carve-out, deliberately narrow because general unknown-option validation was explicitly deferred as this issue. Now that general validation is in place, that carve-out is redundant: `:ssl` is rejected the same way any other unrecognised key is, rather than being silently accepted with a log line. This PR removes `warn_if_legacy_ssl_option/1` and the tests written for it.

## Other changes bundled in

- A key repeated with *conflicting* values (e.g. `port: 7687, port: 9999` in one opts list) now logs a warning — first occurrence wins, matching `Keyword.get/3`. Same-value duplicates (the `[override] ++ base_opts` idiom already used in this codebase, e.g. `timeout_test.exs`) stay silent — deliberately narrow to avoid false-positiving on that idiom.
- Removed `:prefix`/`:max_overflow` from `test/test_helper.exs` — dead test options that were never read anywhere (not real bolty or DBConnection options), caught by the new validation.
- `Keyword.validate/2` was tried first but rejected: it treats each valid key as consumable only once, so it false-positived on the `[pool_size: 1] ++ TestHelper.opts()` override idiom already used in `timeout_test.exs`. Replaced with a plain `MapSet` membership check instead.

## Breaking change

An unrecognised `start_link/1` option (including the removed `:ssl` key) now returns `{:error, %Bolty.Error{code: :invalid_option}}` instead of being silently ignored. Part of the already-breaking 0.3.0 batch.

## Test plan

- [x] `mix test` (unit suite, no live server) — 259 passed
- [x] `BOLT_VERSIONS=5.8 BOLT_TCP_PORT=7687 mix test` (Neo4j 5.26.28) — 357 passed
- [x] `BOLT_VERSIONS=6.0 BOLT_TCP_PORT=7689 mix test` (Neo4j 2026.05) — 341 passed
- [x] `mix format --check-formatted`, `mix credo` (CI's non-strict invocation), `mix dialyzer` all clean

Closes #121