### PR TITLE
fix: redact auth credentials from debug logs (#109, #123)

### DIFF
--- a/lib/bolty/bolt_protocol/message_encoder.ex
+++ b/lib/bolty/bolt_protocol/message_encoder.ex
@@ -21,7 +21,7 @@ defmodule Bolty.BoltProtocol.MessageEncoder do
       |> do_encode(data, policy)
       |> generate_chunks([])
 
-    Bolty.Utils.Logger.log_message(:client, :message_type, encoded, :hex)
+    Bolty.Utils.Logger.log_client_message_hex(encoded, data)
     encoded |> IO.iodata_to_binary()
   end
 

--- a/lib/bolty/utils/logger.ex
+++ b/lib/bolty/utils/logger.ex
@@ -55,6 +55,25 @@ defmodule Bolty.Utils.Logger do
     end
   end
 
+  @doc """
+  Logs the hex of an outgoing client message.
+
+  Unlike the raw hex path, this takes the source message `body` alongside the
+  packed `encoded` bytes: when the body carries secret fields (e.g. a LOGON
+  `credentials`), the raw bytes would contain them in plaintext, so the dump is
+  suppressed and only a marker is logged. Field-level redaction isn't possible
+  once serialized, so suppression is the safe choice.
+  """
+  def log_client_message_hex(encoded, body) do
+    if Application.get_env(:bolty, :log_hex, false) do
+      if sensitive?(body) do
+        do_log_message(:client, fn -> "MESSAGE_TYPE ~ [hex suppressed: contains credentials]" end)
+      else
+        log_message(:client, :message_type, encoded, :hex)
+      end
+    end
+  end
+
   # Recursively replaces the value of any `@redacted_keys` field with a
   # placeholder so secrets never reach the log. Structs are left intact (they
   # don't carry auth secrets, and preserving them keeps logged query params
@@ -71,6 +90,21 @@ defmodule Bolty.Utils.Logger do
   end
 
   defp redact(data), do: data
+
+  # Whether `data` carries any `@redacted_keys` field. Walks the same shapes as
+  # `redact/1` (plain maps and lists, skipping structs).
+  defp sensitive?(data) when is_list(data), do: Enum.any?(data, &sensitive?/1)
+
+  defp sensitive?(%_{}), do: false
+
+  defp sensitive?(%{} = map) do
+    Enum.any?(map, fn
+      {key, _value} when key in @redacted_keys -> true
+      {_key, value} -> sensitive?(value)
+    end)
+  end
+
+  defp sensitive?(_data), do: false
 
   defp do_log_message(from, func) when is_function(func) do
     from_txt =

--- a/lib/bolty/utils/logger.ex
+++ b/lib/bolty/utils/logger.ex
@@ -65,12 +65,15 @@ defmodule Bolty.Utils.Logger do
   once serialized, so suppression is the safe choice.
   """
   def log_client_message_hex(encoded, body) do
-    if Application.get_env(:bolty, :log_hex, false) do
-      if sensitive?(body) do
+    cond do
+      not Application.get_env(:bolty, :log_hex, false) ->
+        :ok
+
+      sensitive?(body) ->
         do_log_message(:client, fn -> "MESSAGE_TYPE ~ [hex suppressed: contains credentials]" end)
-      else
+
+      true ->
         log_message(:client, :message_type, encoded, :hex)
-      end
     end
   end
 

--- a/lib/bolty/utils/logger.ex
+++ b/lib/bolty/utils/logger.ex
@@ -8,6 +8,13 @@ defmodule Bolty.Utils.Logger do
   # The `from` parameter must be a atom, either `:client` or `:server`
   require Logger
 
+  # Message fields whose values are secrets and must never reach the debug log
+  # in plaintext (e.g. the LOGON `credentials`, which is the account password).
+  # Mirrors the `@derive {Inspect, except: [:password]}` redaction on
+  # `Bolty.Client.Config`, closing the same gap on the opt-in log path.
+  @redacted_keys [:credentials]
+  @redacted_placeholder "[REDACTED]"
+
   @doc """
   Produces a formatted Log for a message
 
@@ -27,7 +34,7 @@ defmodule Bolty.Utils.Logger do
   """
   def log_message(from, type, data) do
     if Application.get_env(:bolty, :log) do
-      log_message(from, {type, data})
+      log_message(from, {type, redact(data)})
     end
   end
 
@@ -47,6 +54,23 @@ defmodule Bolty.Utils.Logger do
       end)
     end
   end
+
+  # Recursively replaces the value of any `@redacted_keys` field with a
+  # placeholder so secrets never reach the log. Structs are left intact (they
+  # don't carry auth secrets, and preserving them keeps logged query params
+  # readable); only plain maps and lists are walked.
+  defp redact(data) when is_list(data), do: Enum.map(data, &redact/1)
+
+  defp redact(%_{} = struct), do: struct
+
+  defp redact(%{} = map) do
+    Map.new(map, fn
+      {key, _value} when key in @redacted_keys -> {key, @redacted_placeholder}
+      {key, value} -> {key, redact(value)}
+    end)
+  end
+
+  defp redact(data), do: data
 
   defp do_log_message(from, func) when is_function(func) do
     from_txt =

--- a/test/bolty/utils/logger_test.exs
+++ b/test/bolty/utils/logger_test.exs
@@ -38,6 +38,33 @@ defmodule Bolty.Utils.LoggerTest do
     assert log =~ "keepme"
   end
 
+  describe "log_client_message_hex/2" do
+    setup do
+      Application.put_env(:bolty, :log_hex, true)
+      on_exit(fn -> Application.put_env(:bolty, :log_hex, false) end)
+    end
+
+    test "suppresses the hex dump when the body carries credentials" do
+      body = [%{scheme: "basic", principal: "neo4j", credentials: "supersecret"}]
+      encoded = <<0x68, 0x75, 0x6E, 0x74>>
+
+      log = capture_log(fn -> Logger.log_client_message_hex(encoded, body) end)
+
+      assert log =~ "[hex suppressed: contains credentials]"
+      refute log =~ "0x68"
+    end
+
+    test "dumps hex for a body with no secret fields" do
+      body = [%{query: "RETURN 1"}]
+      encoded = <<0x01, 0xAF>>
+
+      log = capture_log(fn -> Logger.log_client_message_hex(encoded, body) end)
+
+      assert log =~ "0x1"
+      assert log =~ "0xAF"
+    end
+  end
+
   # Excluded as another test has a long result and therefore a long hex and slow down tests
   # test "Log hex data" do
   #   assert capture_log(fn -> Logger.log_message(:client, :success, <<0x01, 0xAF>>, :hex) end) =~

--- a/test/bolty/utils/logger_test.exs
+++ b/test/bolty/utils/logger_test.exs
@@ -18,6 +18,26 @@ defmodule Bolty.Utils.LoggerTest do
              "C: SUCCESS ~ %{data: \"ok\"}"
   end
 
+  test "redacts auth credentials from a logged message body" do
+    body = [%{scheme: "basic", principal: "neo4j", credentials: "supersecret"}]
+
+    log = capture_log(fn -> Logger.log_message(:client, :message_type, body) end)
+
+    refute log =~ "supersecret"
+    assert log =~ "credentials: \"[REDACTED]\""
+    assert log =~ "principal: \"neo4j\""
+  end
+
+  test "redacts nested credentials but leaves query-param structs intact" do
+    body = [%{outer: %{credentials: "supersecret"}, params: %URI{host: "keepme"}}]
+
+    log = capture_log(fn -> Logger.log_message(:client, :message_type, body) end)
+
+    refute log =~ "supersecret"
+    assert log =~ "[REDACTED]"
+    assert log =~ "keepme"
+  end
+
   # Excluded as another test has a long result and therefore a long hex and slow down tests
   # test "Log hex data" do
   #   assert capture_log(fn -> Logger.log_message(:client, :success, <<0x01, 0xAF>>, :hex) end) =~


### PR DESCRIPTION
Closes #109. Closes #123.

Two related credential-in-plaintext-logs leaks in the opt-in debug logging, closed in the same 0.3.0 credential-handling pass.

## #109 — structured log (`config :bolty, :log`)
`Bolty.Utils.Logger` inspected outgoing message bodies verbatim, so a LOGON message printed its `credentials` field (the account password) in plaintext. This mirrored the gap that `@derive {Inspect, except: [:password]}` on `Bolty.Client.Config` already closes for inspect/crash reports.

Fix: redact known secret fields (`:credentials`) before the structured body is inspected. Redaction runs only when logging is enabled, walks plain maps and lists, and leaves structs intact so logged query params stay readable. Wire encoding is untouched.

## #123 — hex log (`config :bolty, :log_hex`)
Found while fixing #109. The raw hex path dumped the packed wire bytes of every outgoing message; for LOGON those bytes contain the PackStream-encoded password in plaintext, so the credential leaked even after #109. Field-level redaction can't be applied once serialized.

Fix: route the client hex log through `Bolty.Utils.Logger.log_client_message_hex/2`, which receives the source message body alongside the encoded bytes. When the body carries a secret field (same `@redacted_keys` set as #109), the dump is suppressed and only a `[hex suppressed: contains credentials]` marker is logged; non-sensitive messages still dump normally. The `log_hex` flag is checked before any per-message sensitivity work, so there's no hot-path cost when hex logging is off.

## Testing
- New unit tests for redaction (structured + nested, structs preserved) and hex suppression (suppressed for credentials, dumped otherwise).
- Verified end-to-end through the real `LogonMessage.encode/2` path: password no longer appears in either log; `RUN` still hex-dumps.
- Full suite green (263 passed).

## Consumer safety
Fully additive; no public API or wire-behaviour change. Only affects what the opt-in debug logs print.