### PR TITLE
feat: server-side routing (SSR) for neo4j:// schemes (#113)

### DIFF
--- a/guides/clustering.md
+++ b/guides/clustering.md
@@ -1,0 +1,120 @@
+<!--
+SPDX-FileCopyrightText: 2024 bolty contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# bolty against a Neo4j cluster
+
+bolty can talk to a Neo4j Enterprise **causal cluster** using server-side
+routing (SSR): you point a connection at one cluster member with a `neo4j://`
+scheme, and the server forwards each statement to the member that can serve it —
+a writable member for writes, a read member for reads — based on the query's
+access mode. This page covers what SSR does, how to enable it, and the caveats
+that matter before you rely on it in production.
+
+> #### Scope {: .info}
+>
+> SSR gives you correct routing (writes reach a leader, reads reach a read
+> member) from a single configured entry point. It is **not** full driver-side
+> cluster routing: bolty does not discover the cluster topology, load-balance
+> across read replicas, or fail over automatically if the configured member goes
+> down. See [Caveats](#caveats) below.
+
+## How it works
+
+Neo4j's `neo4j`/`neo4j+s`/`neo4j+ssc` schemes mean "routed" across the ecosystem,
+in contrast to `bolt`/`bolt+s`/`bolt+ssc`, which mean "connect directly to this
+one server". The distinction is carried on the wire by a single field in the
+Bolt `HELLO` message: when a connection opts into routing, bolty sends
+`routing = %{"address" => "<host>:<port>"}` in the `HELLO` extras (Bolt 4.1+).
+Its presence tells the server "this is a routed connection, forward my
+statements as needed"; its absence means "serve everything here directly".
+
+bolty already sends the two fields the server routes on — `:mode` (`"w"`/`"r"`)
+and `:bookmarks` — through every `RUN` and `BEGIN`. SSR simply lets the server
+act on them.
+
+## Enabling it
+
+Routing is derived from the scheme, so most setups need nothing extra:
+
+```elixir
+# Routed: writes go to a leader, reads to a read member — automatically.
+{:ok, conn} =
+  Bolty.start_link(
+    scheme: "neo4j+s",
+    hostname: "cluster-member-1.example.com",
+    port: 7687,
+    auth: [username: "neo4j", password: System.fetch_env!("NEO4J_PASSWORD")]
+  )
+```
+
+`neo4j*` schemes enable routing by default; `bolt*` schemes disable it. Override
+with the explicit `:routing` option when you need to:
+
+```elixir
+# A neo4j:// URI pointed at a single instance or a proxy — opt out of routing.
+Bolty.start_link(uri: "neo4j://localhost:7687", routing: false, auth: [...])
+
+# Force routing on a bolt:// scheme (unusual — prefer the neo4j:// scheme).
+Bolty.start_link(scheme: "bolt", hostname: "member-1", routing: true, auth: [...])
+```
+
+Precedence follows the rest of bolty's config: an explicit `:routing` option wins
+over the scheme-derived default.
+
+### Choosing an access mode
+
+Under routing, tag reads so they can be served by a read member instead of
+loading the leader:
+
+```elixir
+# Routed to a writable member (default).
+Bolty.query!(conn, "CREATE (:Person {name: $n})", %{n: "Ada"})
+
+# Routed to a read member.
+Bolty.query!(conn, "MATCH (p:Person) RETURN p", %{}, mode: "r")
+```
+
+`:mode` and `:bookmarks` are documented on `Bolty.query/4` and
+`Bolty.transaction/4`.
+
+## Server prerequisites
+
+- **Neo4j Enterprise Edition** running as a causal cluster. SSR does nothing on
+  Community Edition or a standalone server (a routed connection still works — it
+  just resolves to that one server).
+- Routing must be enabled on the cluster members via `dbms.routing.enabled`.
+  Whether that is on by default, and how `dbms.routing.default_router` interacts
+  with it, varies by Neo4j version — **verify the defaults for your specific
+  Enterprise version** rather than assuming; don't take a value stated here or
+  elsewhere as authoritative for your deployment.
+
+## Caveats
+
+Read these before depending on SSR. They are consequences of bolty deliberately
+*not* implementing a full routing driver.
+
+- **You are pinned to one member.** The `address` bolty advertises is the single
+  member you configured. Writes and uncacheable reads that land on the wrong
+  member cost an extra forwarding hop, and there is **no read-replica
+  load-balancing or scaling** — every connection enters through the same member.
+- **No automatic failover.** If the configured member goes down, bolty does not
+  discover another one; new connections to it fail. Front the cluster with DNS
+  or an L4 (TCP) load balancer over the members and point bolty at that name —
+  this composes cleanly with SSR, since routing is negotiated per connection
+  once the TCP connection lands on *any* live member.
+- **Causal consistency is manual.** There is no session abstraction, so
+  read-after-write consistency requires threading bookmarks yourself: read the
+  `bookmark` from a `Bolty.Response` (or the last response in a transaction) and
+  pass it as `:bookmarks` to the next query/transaction. Without this, a read
+  routed to a lagging member may not see a write you just made against the
+  leader.
+- **No topology awareness.** bolty does not fetch or cache a routing table, so it
+  cannot pick "the nearest read replica" or re-route around a demoted leader
+  mid-connection the way the official drivers do.
+
+If you need automatic failover, read-replica load-balancing, or topology-aware
+routing, put a load balancer in front (for failover/spread) and use bookmarks
+(for consistency) — or use an official Neo4j driver that implements full
+client-side routing.

--- a/lib/bolty.ex
+++ b/lib/bolty.ex
@@ -57,6 +57,7 @@ defmodule Bolty do
           | {:hostname, String.t()}
           | {:port, :inet.port_number()}
           | {:scheme, String.t()}
+          | {:routing, boolean()}
           | {:versions, list(String.t() | float())}
           | {:auth, basic_auth()}
           | {:user_agent, String.t()}
@@ -91,7 +92,17 @@ defmodule Bolty do
   * `:scheme` - Is one among neo4j, neo4j+s, neo4j+ssc, bolt, bolt+s, bolt+ssc
    (default: bolt+s). TLS is derived entirely from this: `bolt`/`neo4j` is
    plaintext, `+s` is full certificate verification against the OS trust
-   store, `+ssc` is encrypted but trust-all (self-signed certs).
+   store, `+ssc` is encrypted but trust-all (self-signed certs). The scheme
+   also sets the default for `:routing` (below).
+
+  * `:routing` - Whether to enable server-side routing (SSR) against a Neo4j
+   Enterprise causal cluster, so the server forwards each statement to the
+   right member based on the query's `:mode`/`:bookmarks` (see `query/4`).
+   Defaults to `true` for `neo4j*` schemes and `false` for `bolt*` schemes,
+   matching their meaning across the ecosystem; set it explicitly to override
+   (`routing: false` for a `neo4j://` URI used cosmetically against a single
+   instance or proxy, `routing: true` to force it on a `bolt://` scheme). See
+   the [Clustering guide](clustering.html) for prerequisites and caveats.
 
   * `:versions` - List of Bolt versions to offer during negotiation, as strings
    (`["5.4", "6.0"]`) or `{major, minor..minor}` range tuples (`[{5, 6..8}]`).
@@ -164,6 +175,19 @@ defmodule Bolty do
   ## Options
 
   * `:db` - Target database for multi-database routing (default: server default).
+
+  * `:mode` - Access mode for this query, `"w"` (write, default) or `"r"`
+      (read). Under server-side routing (a `neo4j://` connection to a cluster —
+      see `start_link/1`'s `:routing` and the [Clustering guide](clustering.html))
+      the server uses this to forward the query to a writable or a read member.
+      Without routing it is informational only.
+
+  * `:bookmarks` - A list of bookmark strings for causal consistency: the server
+      will not run this query until it has caught up to the transactions those
+      bookmarks identify. Each `Bolty.Response` carries the bookmark of the
+      transaction that produced it; thread the previous response's bookmark into
+      the next query to chain reads-after-writes. There is no session
+      abstraction, so bookmarks must be passed manually.
 
   * `:recv_timeout` - Overrides the connection's `:recv_timeout` for this query
       (see `start_link/1`). Pass `:infinity` for a query expected to run longer
@@ -247,6 +271,34 @@ defmodule Bolty do
     end
   end
 
+  @doc """
+  Runs `fun` inside a Bolt transaction, committing on return and rolling back on
+  `rollback/2` or a raised error.
+
+  `opts` are passed to `DBConnection.transaction/3`. `extra_parameters` is a map
+  applied to the opening `BEGIN` for the whole transaction:
+
+  * `:mode` - `"w"` (write, default) or `"r"` (read). Under server-side routing
+    (a `neo4j://` connection to a cluster — see `start_link/1`'s `:routing` and
+    the [Clustering guide](clustering.html)) the server routes the transaction to
+    a writable or a read member accordingly.
+
+  * `:bookmarks` - A list of bookmark strings for causal consistency; the
+    transaction will not begin until the server has caught up to the transactions
+    they identify. Read a completed transaction's bookmark from the last
+    `Bolty.Response` it produced and thread it into the next one — there is no
+    session abstraction, so this is manual.
+
+  * `:db` - Target database for the transaction (default: server default).
+
+  ## Example
+
+  ```elixir
+  Bolty.transaction(conn, fn conn ->
+    Bolty.query!(conn, "CREATE (:Person {name: $n})", %{n: "Ada"})
+  end, [], %{mode: "w"})
+  ```
+  """
   @spec transaction(conn, (DBConnection.t() -> result), [DBConnection.option()], map()) ::
           {:ok, result} | {:error, any}
         when result: var

--- a/lib/bolty/bolt_protocol/message/hello_message.ex
+++ b/lib/bolty/bolt_protocol/message/hello_message.ex
@@ -24,8 +24,13 @@ defmodule Bolty.BoltProtocol.Message.HelloMessage do
   end
 
   def encode(bolt_version, fields) when is_tuple(bolt_version) and bolt_version >= {3, 0} do
-    message = [Map.merge(get_auth_params(fields), get_user_agent(bolt_version, fields))]
-    MessageEncoder.encode(@signature, message)
+    extras =
+      fields
+      |> get_auth_params()
+      |> Map.merge(get_user_agent(bolt_version, fields))
+      |> maybe_put_routing(fields)
+
+    MessageEncoder.encode(@signature, [extras])
   end
 
   def encode(_, _) do
@@ -48,5 +53,18 @@ defmodule Bolty.BoltProtocol.Message.HelloMessage do
         do: Map.put(acc, policy.notifications_field, categories_value),
         else: acc
     end)
+    |> maybe_put_routing(fields)
+  end
+
+  # Opt the connection into server-side routing (SSR) by including the HELLO
+  # `routing` field. Config.new/1 resolves this to `%{"address" => "host:port"}`
+  # when on and omits it (nil) when off; its absence tells the server not to
+  # route. The atom key encodes to the wire string "routing" via the PackStream
+  # Atom packer.
+  defp maybe_put_routing(extras, fields) do
+    case Keyword.get(fields, :routing) do
+      nil -> extras
+      routing -> Map.put(extras, :routing, routing)
+    end
   end
 end

--- a/lib/bolty/client.ex
+++ b/lib/bolty/client.ex
@@ -38,7 +38,7 @@ defmodule Bolty.Client do
     @bolty_option_keys ~w(
       uri hostname port scheme versions auth user_agent
       notifications_minimum_severity notifications_disabled_categories
-      ssl_opts connect_timeout recv_timeout socket_options
+      ssl_opts connect_timeout recv_timeout socket_options routing
     )a
 
     # DBConnection.ConnectionPool.Pool prepends `pool_index: id` to every
@@ -63,7 +63,8 @@ defmodule Bolty.Client do
       :versions,
       :ssl?,
       :tls_verify,
-      :ssl_opts
+      :ssl_opts,
+      :routing
     ]
 
     @doc """
@@ -82,7 +83,8 @@ defmodule Bolty.Client do
         {scheme, ssl?, tls_verify, ssl_opts} = get_scheme_and_ssl_opts(opts)
 
         with :ok <- validate_username(username),
-             {:ok, versions} <- get_versions(opts) do
+             {:ok, versions} <- get_versions(opts),
+             {:ok, routing} <- get_routing(opts, scheme, hostname, port) do
           {:ok,
            %__MODULE__{
              hostname: hostname,
@@ -100,7 +102,8 @@ defmodule Bolty.Client do
              versions: versions,
              ssl?: ssl?,
              tls_verify: tls_verify,
-             ssl_opts: ssl_opts
+             ssl_opts: ssl_opts,
+             routing: routing
            }}
         end
       end
@@ -210,6 +213,54 @@ defmodule Bolty.Client do
     defp get_user_and_pass(opts) do
       basic_auth = Keyword.get(opts, :auth, [])
       {Keyword.get(basic_auth, :username), Keyword.get(basic_auth, :password)}
+    end
+
+    # Resolves the Bolt HELLO `routing` field (server-side routing / SSR, Bolt
+    # 4.1+). When set, the server forwards each statement to the right cluster
+    # member using the `:mode`/`:bookmarks` bolty already sends over RUN/BEGIN;
+    # when absent, the server must not route (a plain direct connection).
+    #
+    # Enabled by default for `neo4j`/`neo4j+s`/`neo4j+ssc` schemes — which mean
+    # "routed" everywhere else in the ecosystem — and off for `bolt*`. An
+    # explicit `:routing` boolean overrides either way (same precedence as every
+    # other option: explicit opt > URI-derived > default), so `routing: false`
+    # is the opt-out for a `neo4j://` URI used cosmetically against a single
+    # instance or proxy, and `routing: true` forces it on a `bolt://` scheme.
+    #
+    # Returns `{:ok, %{"address" => "host:port"}}` when on (the extras value the
+    # HELLO encoder sends verbatim), `{:ok, nil}` when off (field omitted), or an
+    # `{:error, %Bolty.Error{}}` for a non-boolean `:routing` rather than
+    # silently ignoring a misconfiguration.
+    defp get_routing(opts, scheme, hostname, port) do
+      case Keyword.fetch(opts, :routing) do
+        {:ok, enabled?} when is_boolean(enabled?) ->
+          {:ok, routing_address(enabled?, hostname, port)}
+
+        {:ok, other} ->
+          {:error,
+           Bolty.Error.wrap(Bolty.Client, %{
+             code: :invalid_routing,
+             message: ":routing must be true or false, got: #{inspect(other)}"
+           })}
+
+        :error ->
+          {:ok, routing_address(routed_scheme?(scheme), hostname, port)}
+      end
+    end
+
+    defp routed_scheme?(scheme), do: scheme in ~w(neo4j neo4j+s neo4j+ssc)
+
+    defp routing_address(false, _hostname, _port), do: nil
+    defp routing_address(true, hostname, port), do: %{"address" => format_address(hostname, port)}
+
+    # Bracket an IPv6 literal so the `host:port` join stays unambiguous
+    # (`[::1]:7687` rather than `::1:7687`). A hostname/IPv4 has no colon.
+    defp format_address(hostname, port) do
+      if String.contains?(hostname, ":") do
+        "[#{hostname}]:#{port}"
+      else
+        "#{hostname}:#{port}"
+      end
     end
 
     # Precedence, uniform across host/port/scheme: explicit opts > URI components

--- a/lib/bolty/connection.ex
+++ b/lib/bolty/connection.ex
@@ -36,7 +36,7 @@ defmodule Bolty.Connection do
       preliminary_policy = Policy.Resolver.resolve(client.bolt_version, %{})
       client_with_policy = %{client | policy: preliminary_policy}
 
-      with {:ok, response_server_metadata} <- do_init(client_with_policy, opts) do
+      with {:ok, response_server_metadata} <- do_init(client_with_policy, opts, config) do
         policy = Policy.Resolver.resolve(client.bolt_version, response_server_metadata)
         state = get_server_metadata_state(response_server_metadata)
         new_state = %__MODULE__{state | client: %{client | policy: policy}, policy: policy}
@@ -258,21 +258,31 @@ defmodule Bolty.Connection do
      end), state}
   end
 
-  defp do_init(client, opts) do
-    do_init(client.bolt_version, client, opts)
+  defp do_init(client, opts, config) do
+    do_init(client.bolt_version, client, opts, config)
   end
 
-  defp do_init(bolt_version, client, opts)
+  defp do_init(bolt_version, client, opts, config)
        when is_tuple(bolt_version) and bolt_version >= {5, 1} do
-    with {:ok, response_hello} <- Client.send_hello(client, opts),
+    with {:ok, response_hello} <- Client.send_hello(client, hello_fields(opts, config)),
          {:ok, _response_logon} <- Client.send_logon(client, opts) do
       {:ok, response_hello}
     end
   end
 
-  defp do_init(bolt_version, client, opts) when is_tuple(bolt_version) do
-    Client.send_hello(client, opts)
+  defp do_init(bolt_version, client, opts, config) when is_tuple(bolt_version) do
+    Client.send_hello(client, hello_fields(opts, config))
   end
+
+  # Carry the resolved HELLO `routing` extras (server-side routing) alongside the
+  # raw start opts. `nil` means routing is off, so the field is omitted entirely
+  # and the connection stays a plain direct one. The user-facing boolean `:routing`
+  # opt (if any) was already consumed by Config.new/1; here it's replaced by the
+  # resolved `%{"address" => ...}` value the HELLO encoder sends verbatim.
+  defp hello_fields(opts, %Client.Config{routing: nil}), do: opts
+
+  defp hello_fields(opts, %Client.Config{routing: routing}),
+    do: Keyword.put(opts, :routing, routing)
 
   defp get_server_metadata_state(response_metadata) do
     hints = Map.get(response_metadata, "hints", "")

--- a/mix.exs
+++ b/mix.exs
@@ -102,7 +102,13 @@ defmodule Bolty.Mixfile do
       source_ref: "v#{@version}",
       source_url: @url_github,
       main: "readme",
-      extras: ["README.md", "guides/public_api.md", "guides/telemetry.md", "CHANGELOG.md"]
+      extras: [
+        "README.md",
+        "guides/public_api.md",
+        "guides/clustering.md",
+        "guides/telemetry.md",
+        "CHANGELOG.md"
+      ]
     ]
   end
 

--- a/test/bolty/bolt_protocol/message_encoder_test.exs
+++ b/test/bolty/bolt_protocol/message_encoder_test.exs
@@ -36,6 +36,23 @@ defmodule Bolty.BoltProtocol.Message.MessageEncoderTest do
       assert <<_, _, _, 0x01, _::binary>> =
                HelloMessage.encode({5, 0}, auth: [username: "hello", password: "hellopw"])
     end
+
+    test "includes the routing field when set (SSR), on both the 5.0 and 5.1+ paths" do
+      routing = %{"address" => "cluster.example.com:7687"}
+
+      for bolt_version <- [{5, 0}, {5, 4}] do
+        encoded = HelloMessage.encode(bolt_version, auth: [username: "u"], routing: routing)
+
+        assert :binary.match(encoded, "routing") != :nomatch
+        assert :binary.match(encoded, "cluster.example.com:7687") != :nomatch
+      end
+    end
+
+    test "omits the routing field when not set" do
+      encoded = HelloMessage.encode({5, 4}, auth: [username: "u"])
+
+      assert :binary.match(encoded, "routing") == :nomatch
+    end
   end
 
   describe "Encode BEGIN" do

--- a/test/bolty/client_config_test.exs
+++ b/test/bolty/client_config_test.exs
@@ -307,6 +307,67 @@ defmodule Bolty.ClientConfigTest do
     end
   end
 
+  describe "server-side routing (:routing)" do
+    @describetag :core
+
+    test "neo4j schemes enable routing by default with the resolved address" do
+      for scheme <- ~w(neo4j neo4j+s neo4j+ssc) do
+        opts = [
+          scheme: scheme,
+          hostname: "cluster.example.com",
+          port: 7687,
+          auth: [username: "u"]
+        ]
+
+        assert {:ok, %Client.Config{routing: %{"address" => "cluster.example.com:7687"}}} =
+                 Client.Config.new(opts)
+      end
+    end
+
+    test "bolt schemes leave routing off by default" do
+      for scheme <- ~w(bolt bolt+s bolt+ssc) do
+        opts = [scheme: scheme, hostname: "single.example.com", port: 7687, auth: [username: "u"]]
+
+        assert {:ok, %Client.Config{routing: nil}} = Client.Config.new(opts)
+      end
+    end
+
+    test "routing: false opts a neo4j scheme out of routing" do
+      opts = [scheme: "neo4j+s", hostname: "h", port: 7687, routing: false, auth: [username: "u"]]
+
+      assert {:ok, %Client.Config{routing: nil}} = Client.Config.new(opts)
+    end
+
+    test "routing: true forces routing on a bolt scheme" do
+      opts = [scheme: "bolt", hostname: "h", port: 7687, routing: true, auth: [username: "u"]]
+
+      assert {:ok, %Client.Config{routing: %{"address" => "h:7687"}}} = Client.Config.new(opts)
+    end
+
+    test "the resolved address derives from URI components when not given explicitly" do
+      opts = [uri: "neo4j://router.example.com:7999", auth: [username: "u"]]
+
+      assert {:ok, %Client.Config{routing: %{"address" => "router.example.com:7999"}}} =
+               Client.Config.new(opts)
+    end
+
+    test "an IPv6 literal host is bracketed in the address" do
+      opts = [scheme: "neo4j", hostname: "::1", port: 7687, auth: [username: "u"]]
+
+      assert {:ok, %Client.Config{routing: %{"address" => "[::1]:7687"}}} =
+               Client.Config.new(opts)
+    end
+
+    test "a non-boolean :routing is a clean config error, not silently ignored" do
+      opts = [scheme: "neo4j", routing: "yes", auth: [username: "u"]]
+
+      assert {:error, %Bolty.Error{code: :invalid_routing, bolt: %{message: message}}} =
+               Client.Config.new(opts)
+
+      assert message =~ "must be true or false"
+    end
+  end
+
   describe "build_tls_opts/4" do
     @describetag :core
     @socket_opts [mode: :binary, packet: :raw, active: false]

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -26,7 +26,7 @@ SPDX-License-Identifier: Apache-2.0
 **Do not use bolty when**:
 - You want Ash-style resources, actions, policies on top of Neo4j — use `ash_neo4j`, which sits on top of bolty.
 - You need **streaming** of large result sets (not implemented; see Feature Support).
-- You need **cluster routing** (not implemented; see Feature Support).
+- You need **full cluster routing** — topology autodiscovery, read-replica load-balancing, or automatic failover (not implemented). Server-side routing (SSR) against a single configured member *is* supported; see the Clustering guide and Feature Support.
 
 If in doubt: agents operating *inside an Ash application* should almost always be going through `ash_neo4j`. bolty is the right tool for driver-level work, tests, benchmarks, and building higher-level abstractions.
 
@@ -89,6 +89,7 @@ Canonical option names (what `Bolty.Client.Config.new/1` actually reads):
 | `:hostname` | Host | `"localhost"` |
 | `:port` | Port | `7687` |
 | `:scheme` | One of the schemes below | `"bolt+s"` |
+| `:routing` | Enable server-side routing (SSR) — `HELLO routing` field. Boolean; overrides the scheme default (`neo4j*` → `true`, `bolt*` → `false`). A non-boolean is a `:invalid_routing` error. See the Clustering guide. | scheme-derived |
 | `:auth` | `[username: ..., password: ...]` (`:username` required) | required |
 | `:versions` | Bolt versions to negotiate. Accepts strings (`["5.4"]`) or range tuples (`[{5, 6..8}, {5, 0..4}]`); floats (`[5.4]`) are deprecated (can't distinguish `5.10` from `5.1`) but still accepted with a warning. Range tuples are preferred — the handshake has only 4 slots and ranges cover more per slot. Omit to use `Versions.latest_versions()`. `connection_info/1` reports the negotiated `bolt_version` as a string (`"5.8"`). | `Versions.latest_versions()` |
 | `:user_agent` | Client identity string | `"bolty/<version>"` |
@@ -190,10 +191,11 @@ Everything else becomes `:unknown`, with the raw map still available in `error.b
 | Vector type pack/unpack (Bolt 6.0) | ✅ — issue [#13](https://github.com/diffo-dev/bolty/issues/13) |
 | Negotiated capability flags via `connection_info/1` | ✅ — `cypher_5`/`cypher_25`/`dynamic_labels` + wire-level dims (see §14) |
 | Streaming result sets | ❌ |
-| Cluster routing (`neo4j://` autodiscovery) | ❌ |
+| Server-side routing (SSR) against a configured cluster member | ✅ — `neo4j://` schemes / `:routing`; see the Clustering guide |
+| Full cluster routing (topology autodiscovery, read-replica load-balancing, auto-failover) | ❌ — front with DNS/L4 LB + bookmarks, or use an official driver |
 | Vector search (indexes, similarity ops) | ❌ — bolty exposes the type; search belongs to the query layer |
 
-If an agent needs routing or streaming today, that is not bolty's job — surface the gap to Matt rather than working around it silently.
+If an agent needs streaming, or cluster routing beyond SSR (autodiscovery/load-balancing/failover), that is not bolty's job — surface the gap to Matt rather than working around it silently.
 
 ## 12. Running tests
 


### PR DESCRIPTION
Closes #113.

`neo4j`/`neo4j+s`/`neo4j+ssc` schemes were pure TLS-intent aliases of their `bolt*` counterparts — nothing on the wire distinguished them. A user pointed at an Enterprise causal cluster with `scheme: "neo4j+s"` silently got a **plain direct connection**: writes to a non-leader fail with `NotALeader`, and bolty has no redirect. Server-side routing (SSR) is opt-in via a `routing` field in the Bolt `HELLO` extras (Bolt 4.1+), which bolty never sent.

## What this does
1. **Sends the HELLO `routing` field** (`%{"address" => "host:port"}`) when routing is enabled. `Client.Config.new/1` resolves it: on by default for `neo4j*` schemes, off for `bolt*`, with an explicit boolean `:routing` opt overriding either way (`routing: false` opts a `neo4j://` URI out; `routing: true` forces it on `bolt`). A non-boolean `:routing` is a clean `%Bolty.Error{code: :invalid_routing}`. IPv6 literals are bracketed. Threaded through the connection into `HelloMessage`, which emits the field on both the 5.0 and 5.1+ encode paths.
2. **Documents `:mode` and `:bookmarks`** on `query/4` and a new `transaction/4` doc — the fields SSR routes on, already sent over RUN/BEGIN but previously invisible. Plus `:routing` on `start_link/1` and the `start_option()` typespec.
3. **Adds `guides/clustering.md`** — how SSR works, prerequisites (EE, `dbms.routing.enabled`, hedged), and caveats: pinned to one member, no read-replica load-balancing, no automatic failover (front with DNS/L4 LB), manual bookmarks for causal consistency. usage-rules.md updated to match.

## Decisions (agreed with owner)
- `:routing` is a **symmetric boolean** override of the scheme default.
- IPv6 addresses are bracketed (`[::1]:7687`).
- **Unit coverage only**: Config resolution + HELLO include/omit. Real cluster routing needs a live EE cluster and stays a manual-verification item; the guide hedges `dbms.routing.enabled` defaults.

## Consumer safety
Fully additive. `bolt`/`bolt+s` users (incl. ash_neo4j) see zero wire change — the field is omitted when routing is off. Verified end-to-end against live 5.26 and 2026.05 servers. Full quality gate green locally (272 passed).