### PR TITLE
docs: correct inverted verify values in usage-rules TLS scheme table

### DIFF
--- a/usage-rules.md
+++ b/usage-rules.md
@@ -108,8 +108,8 @@ Canonical option names (what `Bolty.Client.Config.new/1` actually reads):
 | URI scheme | TLS | ssl_opts merge |
 | --- | --- | --- |
 | `neo4j`, `bolt` | off | — |
-| `neo4j+s`, `bolt+s` | on | `verify: :verify_none` (full cert, but no verification) |
-| `neo4j+ssc`, `bolt+ssc` | on | `verify: :verify_peer` (self-signed allowed) |
+| `neo4j+s`, `bolt+s` | on | `verify: :verify_peer` (full cert verification against the OS trust store) |
+| `neo4j+ssc`, `bolt+ssc` | on | `verify: :verify_none` (encrypted, but self-signed / trust-all) |
 
 Default scheme when nothing is specified is `bolt+s`.
 


### PR DESCRIPTION
Pre-existing docs bug found while working on #113.

The URI-schemes/TLS table in usage-rules.md had the `+s` and `+ssc` verify defaults **swapped**, with self-contradictory parentheticals:

- listed `+s` as `verify: :verify_none` ("full cert, but no verification")
- listed `+ssc` as `verify: :verify_peer` ("self-signed allowed")

The code does the opposite ([client.ex:199-202](https://github.com/diffo-dev/bolty/blob/dev/lib/bolty/client.ex#L199-L202)): `+s` → `:verify` (verify_peer, full CA verification against the OS trust store + SNI + hostname check) and `+ssc` → `:self_signed` (verify_none, encrypted but trust-all). Docs-only correction so each scheme's security posture is stated accurately — squarely on 0.3.0's TLS-hardening theme.