### PR TITLE
feat: lazy result streaming via DBConnection cursor callbacks (#59)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Documentation: [https://hexdocs.pm/bolty](https://hexdocs.pm/bolty)
 | --------------------- | ------------ |
 | Queries               | YES          |
 | Transactions          | YES          |
-| Stream capabilities   | NO           |
-| Routing               | NO           |
+| Streaming             | YES — `Bolty.stream/4` (lazy, server-side backpressure) |
+| Routing               | Partial — server-side routing (SSR) for `neo4j://` schemes; no autodiscovery/failover |
 
 ## Usage
 
@@ -69,6 +69,15 @@ iex> Bolty.query!(conn, "return 1 as n") |> Bolty.Response.first()
 # Commit is performed automatically if everything went fine
 Bolty.transaction(conn, fn conn ->
   result = Bolty.query!(conn, "CREATE (m:Movie {title: 'Matrix'}) RETURN m")
+end)
+
+# Lazily stream a large result in batches (server-side backpressure).
+# Must be enumerated inside a transaction; :fetch_size sets the batch size.
+Bolty.transaction(conn, fn conn ->
+  conn
+  |> Bolty.stream("MATCH (n) RETURN n", %{}, fetch_size: 500)
+  |> Stream.flat_map(& &1.results)
+  |> Enum.each(&IO.inspect/1)
 end)
 
 ```
@@ -267,7 +276,8 @@ Supported element types:
 ## Telemetry
 
 Bolty emits [`:telemetry`](https://hexdocs.pm/telemetry) events for the query
-(`[:bolty, :query, :start | :stop | :exception]`) and connection
+(`[:bolty, :query, :start | :stop | :exception]`), streaming
+(`[:bolty, :stream, :start | :fetch | :stop]`), and connection
 (`[:bolty, :connect | :disconnect]`) lifecycle, so you can attach query latency,
 pool health, and error-rate metrics without wrapping every call site. See the
 [Telemetry guide](guides/telemetry.md) for the full event/measurement/metadata

--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -17,6 +17,7 @@ Attach a handler at application start:
   [
     [:bolty, :query, :stop],
     [:bolty, :query, :exception],
+    [:bolty, :stream, :stop],
     [:bolty, :connect],
     [:bolty, :disconnect]
   ],
@@ -54,6 +55,26 @@ Metadata keys:
   `%DBConnection.ConnectionError{}`) returned to the caller.
 
 Query **parameters are not included** in metadata — they routinely carry secrets.
+
+## Streaming events
+
+`Bolty.stream/3` is lazy and consumer-paced, so it does **not** use the eager
+`[:bolty, :query]` span (which would close before any records are pulled).
+Instead it emits three discrete events over the cursor's lifetime:
+
+| Event | Measurements | Metadata |
+| --- | --- | --- |
+| `[:bolty, :stream, :start]` | `:system_time` | `:db_system`, `:db_statement`, `:db_instance`, `:fetch_size` |
+| `[:bolty, :stream, :fetch]` | `:records` | `:db_system`, `:has_more` |
+| `[:bolty, :stream, :stop]` | `:duration` | `:db_system` |
+
+- `:start` fires once when the stream's `RUN` is declared; `:fetch` fires once
+  per batch (`PULL`) with `:records` (the batch size) and `:has_more` (whether
+  more batches follow); `:stop` fires once when the cursor is released, with the
+  total wall-clock `:duration` of the stream.
+- Sum `:fetch` `:records` for the total streamed; pair `:start`/`:stop` for
+  timing. As with query events, the Cypher statement is included but
+  **parameters are not**.
 
 ## Connection events
 

--- a/lib/bolty.ex
+++ b/lib/bolty.ex
@@ -285,6 +285,12 @@ defmodule Bolty do
   statement's server-assigned query id, which only exists within an explicit
   transaction. Enumerate the stream within the same transaction callback.
 
+  Unlike `query/4`, a failure mid-stream is surfaced by **raising** a
+  `Bolty.Error` while the stream is being enumerated (the `Enumerable` protocol
+  has no error-tuple channel), rather than returning `{:error, _}`. The error
+  value is the same `%Bolty.Error{}`; the connection is RESET-recovered and
+  returns clean to the pool, and the enclosing transaction rolls back.
+
   ## Options
 
   * `:fetch_size` - Records to pull per batch (the Bolt `PULL n`). Default
@@ -304,7 +310,7 @@ defmodule Bolty do
   end)
   ```
   """
-  @spec stream(DBConnection.t(), String.t(), map(), keyword()) :: DBConnection.PrepareStream.t()
+  @spec stream(DBConnection.t(), String.t(), map(), keyword()) :: DBConnection.Stream.t()
   def stream(conn, statement, params \\ %{}, opts \\ []) do
     formatted_params = Map.new(params)
 

--- a/lib/bolty.ex
+++ b/lib/bolty.ex
@@ -272,6 +272,53 @@ defmodule Bolty do
   end
 
   @doc """
+  Lazily streams a query's result in batches, with server-side backpressure.
+
+  Returns a `DBConnection` stream that pulls records from the server in batches
+  as it is enumerated, rather than materialising the whole result up front like
+  `query/4`. Each element is a `%Bolty.Response{}` for one batch — its `results`
+  and `records` are that batch's records; the summary metadata (`stats`,
+  `bookmark`, …) lands on the final batch. Enumerating only part of the stream
+  fetches only the batches consumed; the rest is discarded server-side.
+
+  **Must be called inside a `transaction/4`** — streaming pages against the
+  statement's server-assigned query id, which only exists within an explicit
+  transaction. Enumerate the stream within the same transaction callback.
+
+  ## Options
+
+  * `:fetch_size` - Records to pull per batch (the Bolt `PULL n`). Default
+      `1000`. Smaller batches mean more round-trips but lower peak memory.
+
+  * `:mode`, `:bookmarks`, `:db` - As documented on `query/4`, applied to the
+      streamed statement's `RUN`.
+
+  ## Example
+
+  ```elixir
+  Bolty.transaction(conn, fn conn ->
+    conn
+    |> Bolty.stream("MATCH (n:Person) RETURN n", %{}, fetch_size: 500)
+    |> Stream.flat_map(& &1.results)
+    |> Enum.each(&process/1)
+  end)
+  ```
+  """
+  @spec stream(DBConnection.t(), String.t(), map(), keyword()) :: DBConnection.PrepareStream.t()
+  def stream(conn, statement, params \\ %{}, opts \\ []) do
+    formatted_params = Map.new(params)
+
+    extra =
+      opts
+      |> Keyword.take([:bookmarks, :mode, :db, :tx_metadata])
+      |> Enum.into(%{})
+
+    query = %Bolty.Query{statement: statement, extra: extra}
+
+    DBConnection.stream(conn, query, formatted_params, opts)
+  end
+
+  @doc """
   Runs `fun` inside a Bolt transaction, committing on return and rolling back on
   `rollback/2` or a raised error.
 

--- a/lib/bolty/connection.ex
+++ b/lib/bolty/connection.ex
@@ -180,8 +180,18 @@ defmodule Bolty.Connection do
       {:ok, run_success} ->
         qid = Map.get(run_success, "qid", -1)
         cursor = %{qid: qid, fields: Map.get(run_success, "fields", []), fetch_size: fetch_size}
-        state = %{state | open_cursors: Map.put(state.open_cursors, qid, true)}
-        {:ok, query, cursor, state}
+
+        stream_telemetry(:start, %{system_time: System.system_time()}, %{
+          db_statement: statement,
+          db_instance: Map.get(extra, :db),
+          fetch_size: fetch_size
+        })
+
+        # Track the cursor for the stream's lifetime: `start_time` for the :stop
+        # duration, `discardable` for whether records remain to DISCARD at
+        # deallocate. Both live until handle_deallocate (always called).
+        entry = %{start_time: System.monotonic_time(), discardable: true}
+        {:ok, query, cursor, %{state | open_cursors: Map.put(state.open_cursors, qid, entry)}}
 
       {:error, error} ->
         declare_or_fetch_failure(client, error, state)
@@ -197,25 +207,27 @@ defmodule Bolty.Connection do
     %__MODULE__{client: client} = state
 
     case Client.send_pull(client, %{n: fetch_size, qid: qid}) do
-      {:ok, pull_result(success_data: success_data) = result_pull} ->
+      {:ok, pull_result(records: records, success_data: success_data) = result_pull} ->
         response =
           Response.new(
             statement_result(result_run: %{"fields" => fields}, result_pull: result_pull)
           )
 
-        if Map.get(success_data, "has_more", false) do
+        has_more = Map.get(success_data, "has_more", false)
+        stream_telemetry(:fetch, %{records: length(records)}, %{has_more: has_more})
+
+        if has_more do
           {:cont, response, state}
         else
-          {:halt, response, %{state | open_cursors: Map.delete(state.open_cursors, qid)}}
+          # Drained: no records remain server-side, so mark the cursor
+          # non-discardable (keep the entry so handle_deallocate still emits :stop).
+          {:halt, response, mark_undiscardable(state, qid)}
         end
 
       {:error, error} ->
-        # Drop the qid first: after a FAILURE the recovery RESET clears the
-        # server-side cursor, so handle_deallocate must not DISCARD it.
-        declare_or_fetch_failure(client, error, %{
-          state
-          | open_cursors: Map.delete(state.open_cursors, qid)
-        })
+        # After a FAILURE the recovery RESET clears the server-side cursor, so
+        # mark it non-discardable; handle_deallocate must not DISCARD it.
+        declare_or_fetch_failure(client, error, mark_undiscardable(state, qid))
     end
   end
 
@@ -224,15 +236,23 @@ defmodule Bolty.Connection do
   # it would error. Always drop it from the tracking map.
   @impl true
   def handle_deallocate(query, %{qid: qid}, _opts, state) do
-    drained_state = %{state | open_cursors: Map.delete(state.open_cursors, qid)}
+    entry = Map.get(state.open_cursors, qid)
+    closed_state = %{state | open_cursors: Map.delete(state.open_cursors, qid)}
 
-    if Map.has_key?(state.open_cursors, qid) do
+    if entry do
+      stream_telemetry(:stop, %{duration: System.monotonic_time() - entry.start_time}, %{})
+    end
+
+    # DISCARD only a cursor still holding records server-side (early
+    # termination). A drained or RESET-cleared cursor's qid is already closed,
+    # so DISCARDing it would error.
+    if entry && entry.discardable do
       case Client.send_discard(state.client, %{n: -1, qid: qid}) do
-        {:ok, _} -> {:ok, query, drained_state}
-        {:error, error} -> {:disconnect, error, drained_state}
+        {:ok, _} -> {:ok, query, closed_state}
+        {:error, error} -> {:disconnect, error, closed_state}
       end
     else
-      {:ok, query, drained_state}
+      {:ok, query, closed_state}
     end
   end
 
@@ -330,6 +350,31 @@ defmodule Bolty.Connection do
 
   defp declare_or_fetch_failure(_client, error, state) do
     {:disconnect, error, state}
+  end
+
+  # Marks a stream cursor as having no records left to DISCARD (drained or
+  # RESET-cleared), keeping its tracking entry so handle_deallocate still emits
+  # the :stop event. A no-op if the qid isn't tracked.
+  defp mark_undiscardable(state, qid) do
+    case Map.get(state.open_cursors, qid) do
+      nil ->
+        state
+
+      entry ->
+        %{state | open_cursors: Map.put(state.open_cursors, qid, %{entry | discardable: false})}
+    end
+  end
+
+  # Emits a `[:bolty, :stream, event]` telemetry event for lazy streaming
+  # (Bolty.stream/3): `:start` at declare, `:fetch` per PULL batch (records +
+  # has_more), `:stop` at deallocate (total wall-clock duration). See
+  # `guides/telemetry.md`.
+  defp stream_telemetry(event, measurements, metadata) do
+    :telemetry.execute(
+      [:bolty, :stream, event],
+      measurements,
+      Map.put(metadata, :db_system, "neo4j")
+    )
   end
 
   defp result(

--- a/lib/bolty/connection.ex
+++ b/lib/bolty/connection.ex
@@ -18,8 +18,15 @@ defmodule Bolty.Connection do
     :hints,
     :connection_id,
     :policy,
-    in_transaction: false
+    in_transaction: false,
+    # qids of declared stream cursors that still have records pending
+    # server-side. handle_fetch removes a qid once its result is drained
+    # (has_more false); handle_deallocate DISCARDs only what remains here, so a
+    # fully-consumed stream isn't DISCARDed against an already-closed qid.
+    open_cursors: %{}
   ]
+
+  @default_fetch_size 1000
 
   @impl true
   def connect(opts) do
@@ -154,12 +161,81 @@ defmodule Bolty.Connection do
   def handle_prepare(query, _opts, state), do: {:ok, query, state}
   @impl true
   def handle_close(query, _opts, state), do: {:ok, query, state}
+  # Declare a server-side cursor for lazy streaming (DBConnection.stream/4, via
+  # Bolty.stream/3). Sends RUN only — no PULL — capturing the `qid` and `fields`
+  # from the RUN SUCCESS. Must run inside a transaction (DBConnection.stream
+  # enforces this); the explicit transaction is what makes the server assign a
+  # qid, which subsequent PULL/DISCARD page against.
   @impl true
-  def handle_deallocate(query, _cursor, _opts, state), do: {:ok, query, state}
+  def handle_declare(
+        %Bolty.Query{statement: statement, extra: extra} = query,
+        params,
+        opts,
+        state
+      ) do
+    %__MODULE__{client: client} = state
+    fetch_size = Keyword.get(opts, :fetch_size, @default_fetch_size)
+
+    case Client.send_run(client, statement, params, extra) do
+      {:ok, run_success} ->
+        qid = Map.get(run_success, "qid", -1)
+        cursor = %{qid: qid, fields: Map.get(run_success, "fields", []), fetch_size: fetch_size}
+        state = %{state | open_cursors: Map.put(state.open_cursors, qid, true)}
+        {:ok, query, cursor, state}
+
+      {:error, error} ->
+        declare_or_fetch_failure(client, error, state)
+    end
+  end
+
+  # Fetch the next batch: PULL {n: fetch_size, qid}. Each batch is surfaced as a
+  # `%Bolty.Response{}` (its `results`/`records` are that batch; summary/stats/
+  # bookmark land on the final batch's SUCCESS). `has_more` decides whether the
+  # cursor continues (`:cont`) or is exhausted (`:halt`).
   @impl true
-  def handle_declare(query, _params, _opts, state), do: {:ok, query, state, nil}
+  def handle_fetch(_query, %{qid: qid, fields: fields, fetch_size: fetch_size}, _opts, state) do
+    %__MODULE__{client: client} = state
+
+    case Client.send_pull(client, %{n: fetch_size, qid: qid}) do
+      {:ok, pull_result(success_data: success_data) = result_pull} ->
+        response =
+          Response.new(
+            statement_result(result_run: %{"fields" => fields}, result_pull: result_pull)
+          )
+
+        if Map.get(success_data, "has_more", false) do
+          {:cont, response, state}
+        else
+          {:halt, response, %{state | open_cursors: Map.delete(state.open_cursors, qid)}}
+        end
+
+      {:error, error} ->
+        # Drop the qid first: after a FAILURE the recovery RESET clears the
+        # server-side cursor, so handle_deallocate must not DISCARD it.
+        declare_or_fetch_failure(client, error, %{
+          state
+          | open_cursors: Map.delete(state.open_cursors, qid)
+        })
+    end
+  end
+
+  # Release a cursor. Only DISCARD one still holding records server-side (early
+  # termination); a fully-drained cursor's qid is already closed, so DISCARDing
+  # it would error. Always drop it from the tracking map.
   @impl true
-  def handle_fetch(query, _cursor, _opts, state), do: {:cont, query, state}
+  def handle_deallocate(query, %{qid: qid}, _opts, state) do
+    drained_state = %{state | open_cursors: Map.delete(state.open_cursors, qid)}
+
+    if Map.has_key?(state.open_cursors, qid) do
+      case Client.send_discard(state.client, %{n: -1, qid: qid}) do
+        {:ok, _} -> {:ok, query, drained_state}
+        {:error, error} -> {:disconnect, error, drained_state}
+      end
+    else
+      {:ok, query, drained_state}
+    end
+  end
+
   @impl true
   def handle_status(_opts, %__MODULE__{in_transaction: true} = state), do: {:transaction, state}
   def handle_status(_opts, state), do: {:idle, state}
@@ -236,6 +312,24 @@ defmodule Bolty.Connection do
     end
   rescue
     _ -> {:disconnect, error, state}
+  end
+
+  # Shared error handling for the streaming RUN (handle_declare) and PULL
+  # (handle_fetch). A recv timeout leaves the socket desynced, so tear the
+  # connection down; any other FAILURE follows the same RESET-recovery as the
+  # eager path (see execute/4) so a bad streamed query doesn't poison the pooled
+  # connection. Both return shapes ({:error, _, _} / {:disconnect, _, _}) are
+  # valid for the declare and fetch callbacks.
+  defp declare_or_fetch_failure(_client, %Bolty.Error{code: :timeout} = error, state) do
+    {:disconnect, error, state}
+  end
+
+  defp declare_or_fetch_failure(client, %Bolty.Error{} = error, state) do
+    recover_from_failure(client, error, state)
+  end
+
+  defp declare_or_fetch_failure(_client, error, state) do
+    {:disconnect, error, state}
   end
 
   defp result(

--- a/test/bolty/connection_test.exs
+++ b/test/bolty/connection_test.exs
@@ -261,32 +261,10 @@ defmodule Bolty.ConnectionTest do
     end
   end
 
-  describe "Connection.handle_deallocate/4" do
-    @tag :core
-    test "successful" do
-      opts = [pool_size: 1] ++ @opts
-      {:ok, conn_data} = Connection.connect(opts)
-      assert {:ok, "", conn_data} == Connection.handle_deallocate("", "", %{}, conn_data)
-    end
-  end
-
-  describe "Connection.handle_declare/3" do
-    @tag :core
-    test "successful" do
-      opts = [pool_size: 1] ++ @opts
-      {:ok, conn_data} = Connection.connect(opts)
-      assert {:ok, "", conn_data, nil} == Connection.handle_declare("", "", %{}, conn_data)
-    end
-  end
-
-  describe "Connection.handle_fetch/3" do
-    @tag :core
-    test "successful" do
-      opts = [pool_size: 1] ++ @opts
-      {:ok, conn_data} = Connection.connect(opts)
-      assert {:cont, "", conn_data} == Connection.handle_fetch("", "", %{}, conn_data)
-    end
-  end
+  # handle_declare/4, handle_fetch/4 and handle_deallocate/4 are exercised
+  # end-to-end against a live server in test/streaming_test.exs (they now run
+  # RUN/PULL/DISCARD over a real cursor lifecycle rather than the old no-op
+  # stubs, so an isolated unit assertion on their return shape isn't meaningful).
 
   describe "Connection.handle_status/2" do
     @tag :core

--- a/test/streaming_test.exs
+++ b/test/streaming_test.exs
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule StreamingTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :integration
+
+  alias Bolty.Response
+
+  @opts Bolty.TestHelper.opts()
+
+  setup do
+    {:ok, conn} = Bolty.start_link([pool_size: 1] ++ @opts)
+    {:ok, conn: conn}
+  end
+
+  @tag :core
+  test "streams a large result in fetch_size batches, preserving order and count", %{conn: conn} do
+    {:ok, batches} =
+      Bolty.transaction(conn, fn c ->
+        c
+        |> Bolty.stream("UNWIND range(1, 250) AS i RETURN i", %{}, fetch_size: 100)
+        |> Enum.to_list()
+      end)
+
+    # 250 records at fetch_size 100 -> three batches of 100, 100, 50.
+    assert Enum.map(batches, &length(&1.results)) == [100, 100, 50]
+
+    all = batches |> Enum.flat_map(& &1.results) |> Enum.map(& &1["i"])
+    assert length(all) == 250
+    assert List.first(all) == 1
+    assert List.last(all) == 250
+  end
+
+  @tag :core
+  test "each batch is a %Bolty.Response{}; summary lands on the final batch only", %{conn: conn} do
+    {:ok, batches} =
+      Bolty.transaction(conn, fn c ->
+        c
+        |> Bolty.stream("UNWIND range(1, 150) AS i RETURN i AS n", %{}, fetch_size: 100)
+        |> Enum.to_list()
+      end)
+
+    assert Enum.all?(batches, &match?(%Response{}, &1))
+    assert Enum.all?(batches, &(&1.fields == ["n"]))
+
+    # The trailing SUCCESS (type/bookmark) arrives with the last batch, not the first.
+    assert List.first(batches).type == nil
+    assert List.last(batches).type != nil
+  end
+
+  @tag :core
+  test "early termination stops fetching and returns the connection clean", %{conn: conn} do
+    {:ok, taken} =
+      Bolty.transaction(conn, fn c ->
+        c
+        |> Bolty.stream("UNWIND range(1, 1000) AS i RETURN i", %{}, fetch_size: 100)
+        |> Stream.flat_map(& &1.results)
+        |> Enum.take(250)
+      end)
+
+    assert length(taken) == 250
+    assert List.last(taken)["i"] == 250
+
+    # The remainder was DISCARDed at deallocate; the pooled connection is usable.
+    assert {:ok, %Response{results: [%{"n" => 7}]}} = Bolty.query(conn, "RETURN 7 AS n")
+  end
+
+  @tag :core
+  test "fetch_size defaults to 1000", %{conn: conn} do
+    {:ok, batch_count} =
+      Bolty.transaction(conn, fn c ->
+        c
+        |> Bolty.stream("UNWIND range(1, 1000) AS i RETURN i")
+        |> Enum.count()
+      end)
+
+    assert batch_count == 1
+  end
+
+  @tag :core
+  test "a failing streamed query raises without poisoning the connection", %{conn: conn} do
+    # A stream surfaces a mid-fetch failure by raising during enumeration (the
+    # Enumerable protocol has no error-tuple channel), unlike query/4's
+    # {:error, _}. The raise propagates out of the transaction fun.
+    assert_raise Bolty.Error, fn ->
+      Bolty.transaction(conn, fn c ->
+        c
+        |> Bolty.stream("RETURN 1 / 0 AS boom")
+        |> Enum.to_list()
+      end)
+    end
+
+    # RESET recovery leaves the pooled connection usable for the next checkout.
+    assert {:ok, %Response{results: [%{"n" => 7}]}} = Bolty.query(conn, "RETURN 7 AS n")
+  end
+
+  @tag :core
+  test "emits :start, one :fetch per batch, and a single :stop", %{conn: conn} do
+    events = [[:bolty, :stream, :start], [:bolty, :stream, :fetch], [:bolty, :stream, :stop]]
+    handler = "streaming-test-#{inspect(self())}"
+    me = self()
+
+    :telemetry.attach_many(
+      handler,
+      events,
+      fn event, measurements, metadata, _ -> send(me, {event, measurements, metadata}) end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler) end)
+
+    {:ok, _} =
+      Bolty.transaction(conn, fn c ->
+        c
+        |> Bolty.stream("UNWIND range(1, 250) AS i RETURN i", %{}, fetch_size: 100)
+        |> Stream.run()
+      end)
+
+    assert_receive {[:bolty, :stream, :start], %{system_time: _}, %{fetch_size: 100}}
+
+    assert_receive {[:bolty, :stream, :fetch], %{records: 100}, %{has_more: true}}
+    assert_receive {[:bolty, :stream, :fetch], %{records: 100}, %{has_more: true}}
+    assert_receive {[:bolty, :stream, :fetch], %{records: 50}, %{has_more: false}}
+
+    assert_receive {[:bolty, :stream, :stop], %{duration: _}, %{db_system: "neo4j"}}
+  end
+end

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -25,7 +25,7 @@ SPDX-License-Identifier: Apache-2.0
 
 **Do not use bolty when**:
 - You want Ash-style resources, actions, policies on top of Neo4j — use `ash_neo4j`, which sits on top of bolty.
-- You need **streaming** of large result sets (not implemented; see Feature Support).
+- (Streaming of large result sets *is* supported now — see `Bolty.stream/4` and Feature Support — so this is no longer a reason to reach past bolty.)
 - You need **full cluster routing** — topology autodiscovery, read-replica load-balancing, or automatic failover (not implemented). Server-side routing (SSR) against a single configured member *is* supported; see the Clustering guide and Feature Support.
 
 If in doubt: agents operating *inside an Ash application* should almost always be going through `ash_neo4j`. bolty is the right tool for driver-level work, tests, benchmarks, and building higher-level abstractions.
@@ -71,6 +71,7 @@ Supervisor.start_link(children, strategy: :one_for_one)
 | `Bolty.query(conn, cypher, params \\ %{}, opts \\ [])` | Run one query | Returns `{:ok, %Bolty.Response{}} \| {:error, %Bolty.Error{}}`. |
 | `Bolty.query!/4` | Raising variant | Raises `Bolty.Error` on failure. |
 | `Bolty.query_many/4`, `query_many!/4` | Run a batch of statements | Returns list of responses. |
+| `Bolty.stream(conn, cypher, params \\ %{}, opts \\ [])` | Lazily stream a large result in batches | Returns a `DBConnection` stream of `%Bolty.Response{}` (one per batch). **Must be enumerated inside a `transaction/4`**. `:fetch_size` opt (default 1000). A mid-stream failure **raises** `%Bolty.Error{}` (streams have no error-tuple channel). |
 | `Bolty.transaction(conn, fun, opts \\ [], extra \\ %{})` | Transaction | `extra` is threaded into the BEGIN message (see §7). |
 | `Bolty.rollback(conn, reason)` | Explicit rollback | Delegates to `DBConnection.rollback/2`. |
 | `Bolty.Response.first/1` | Grab the first result row | Returns a map `%{field => value}` or `nil`. |
@@ -190,12 +191,12 @@ Everything else becomes `:unknown`, with the raw map still available in `error.b
 | Notifications opt-out (Bolt 5.2+) | ✅ |
 | Vector type pack/unpack (Bolt 6.0) | ✅ — issue [#13](https://github.com/diffo-dev/bolty/issues/13) |
 | Negotiated capability flags via `connection_info/1` | ✅ — `cypher_5`/`cypher_25`/`dynamic_labels` + wire-level dims (see §14) |
-| Streaming result sets | ❌ |
+| Streaming result sets (lazy, server-side backpressure) | ✅ — `Bolty.stream/4` inside a transaction; `:fetch_size` batches, `[:bolty, :stream, *]` telemetry |
 | Server-side routing (SSR) against a configured cluster member | ✅ — `neo4j://` schemes / `:routing`; see the Clustering guide |
 | Full cluster routing (topology autodiscovery, read-replica load-balancing, auto-failover) | ❌ — front with DNS/L4 LB + bookmarks, or use an official driver |
 | Vector search (indexes, similarity ops) | ❌ — bolty exposes the type; search belongs to the query layer |
 
-If an agent needs streaming, or cluster routing beyond SSR (autodiscovery/load-balancing/failover), that is not bolty's job — surface the gap to Matt rather than working around it silently.
+If an agent needs cluster routing beyond SSR (autodiscovery/load-balancing/failover), that is not bolty's job — surface the gap to Matt rather than working around it silently.
 
 ## 12. Running tests
 
@@ -248,7 +249,7 @@ Init dispatch in `Bolty.Connection.do_init/3`:
 - Bolt 5.0 → `HELLO`.
 - Bolt ≥ 5.1 → `HELLO` then `LOGON` (auth split out of HELLO).
 
-`handle_execute/4` always runs via `DBConnection.prepare_execute` — bolty does **not** use real prepared statements; `DBConnection.Query` is implemented as a no-op passthrough in `lib/bolty/query.ex`. `handle_prepare`, `handle_close`, `handle_declare`, `handle_fetch`, `handle_deallocate` are all trivial; `handle_status` is hardcoded to `:idle`. Revisit if true streaming lands.
+`handle_execute/4` always runs via `DBConnection.prepare_execute` — bolty does **not** use real prepared statements; `DBConnection.Query` is implemented as a no-op passthrough in `lib/bolty/query.ex`. `handle_prepare`/`handle_close` are trivial and `handle_status` is hardcoded to `:idle`, but `handle_declare`/`handle_fetch`/`handle_deallocate` now implement real server-side cursor streaming (RUN → PULL `{n, qid}` → DISCARD) behind `Bolty.stream/4`.
 
 Fork posture: drift from boltx is minimised on purpose. When applying fixes, prefer surgical patches over refactors so upstream back-ports remain feasible.
 


### PR DESCRIPTION
Closes #59.

Implements lazy, server-side-backpressured result streaming — the three DBConnection cursor callbacks (previously non-functional stubs) plus a thin `Bolty.stream/4`. A stream pulls records in batches as it's enumerated instead of materialising the whole result like `query/4`. Independent of and zero change to the eager path.

## How it works
- **`handle_declare/4`** sends RUN only (no PULL), capturing `qid` + `fields` from the RUN SUCCESS. Runs inside a transaction (DBConnection.stream enforces this) — the explicit tx is what makes the server assign a `qid` to page against.
- **`handle_fetch/4`** sends `PULL {n: fetch_size, qid}`; surfaces each batch as a `%Bolty.Response{}` (results/records for that batch; summary/stats/bookmark on the final batch). `has_more` decides `:cont` vs `:halt`.
- **`handle_deallocate/4`** DISCARDs only a cursor still holding records (early termination), tracked via `open_cursors` in state, so a drained/RESET-cleared qid isn't DISCARDed after it's closed.
- **Failure handling** reuses the eager path's RESET-recovery so a bad streamed query can't poison the pooled connection; a recv timeout disconnects (desynced socket).

## Decisions (agreed with owner)
- **`:fetch_size`, default 1000** (Neo4j-native term, not `:max_rows`). Plus `:mode`/`:bookmarks`/`:db` lifted into the RUN like `query/4`.
- **`%Bolty.Response{}` per batch**; summary only on the final batch.
- **Discrete telemetry**: `[:bolty, :stream, :start | :fetch | :stop]` (a lazy stream doesn't fit the eager `[:bolty, :query]` span). `:fetch` carries `%{records: n}` + `has_more`; `:stop` the total duration.
- **Transaction-only**, documented (matches Postgrex/DBConnection).

## Error surface
Preserved: a mid-stream failure yields the same `%Bolty.Error{}` as `query/4`, but a stream **raises** it during enumeration (the `Enumerable` protocol has no error-tuple channel) rather than returning `{:error, _}` — same as Postgrex/Ecto streams. Connection RESET-recovers and returns clean to the pool. Documented on `Bolty.stream/4`.

## Tests
`test/streaming_test.exs` (integration): fetch_size batching + order/count, per-batch `%Bolty.Response{}` with summary on the final batch only, early termination (DISCARDs remainder, pool stays clean), default fetch_size, a failing query raising `%Bolty.Error{}` without poisoning the connection, and the `:start`/`:fetch`/`:stop` telemetry. Removed three obsolete unit tests that asserted the old no-op stub return shapes.

## Docs
`Bolty.stream/4` doc (tx requirement, `:fetch_size`, raise-on-error); telemetry guide Streaming section; README (Features table — streaming YES, and corrected the stale Routing row to reflect #113's SSR; usage example; telemetry list); usage-rules (API table, feature matrix, maintainer note).

## Quality gate
compile --warnings-as-errors, credo, format, **dialyzer**, docs, REUSE, and the full integration suite (358 passed) all green locally. Verified end-to-end against a live 5.26 server: 1000 records stream in fetch_size batches; early termination discards the remainder; telemetry fires start → one :fetch per batch → single :stop.