### PR TITLE
chore: correct copyright year 2024 → 2025

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 # This file contains the configuration for Credo.

--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 []

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 # Used by "mix format" and to export configuration.

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 #
 # Pre-push hook: run the fast half of CI's "Code Quality Checks" (lint) job so

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 /.github/CODEOWNERS @diffo-dev

--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 ---

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 version: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 name: CI

--- a/.iex.exs
+++ b/.iex.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 try do

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024 bolty contributors
+SPDX-FileCopyrightText: 2025 bolty contributors
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024 bolty contributors
+SPDX-FileCopyrightText: 2025 bolty contributors
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/NOTICE
+++ b/NOTICE
@@ -14,7 +14,7 @@ attribution and redistributes under the same licence.
     https://github.com/sagastume/boltx
 
   bolty
-    Copyright 2024 bolty contributors.
+    Copyright 2025 Matt Beanland and contributors.
     https://github.com/diffo-dev/bolty
 
 Copyright in each generation is held by its contributors, as recorded in

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024 bolty contributors
+SPDX-FileCopyrightText: 2025 bolty contributors
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -14,17 +14,17 @@ path = [
     ".tool-versions",
 ]
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2024 bolty contributors"
+SPDX-FileCopyrightText = "2025 bolty contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "mix.lock"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2024 bolty contributors"
+SPDX-FileCopyrightText = "2025 bolty contributors"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "NOTICE"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2024 bolty contributors"
+SPDX-FileCopyrightText = "2025 bolty contributors"
 SPDX-License-Identifier = "Apache-2.0"

--- a/benchees/conn_to_local_bench.exs
+++ b/benchees/conn_to_local_bench.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 # benchmark the time it takes to open connections to a local neo4j server.

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 # This file is responsible for configuring your application

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 import Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 import Config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 services:

--- a/guides/clustering.md
+++ b/guides/clustering.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024 bolty contributors
+SPDX-FileCopyrightText: 2025 bolty contributors
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/guides/public_api.md
+++ b/guides/public_api.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024 bolty contributors
+SPDX-FileCopyrightText: 2025 bolty contributors
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024 bolty contributors
+SPDX-FileCopyrightText: 2025 bolty contributors
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/lib/bolty.ex
+++ b/lib/bolty.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty do

--- a/lib/bolty/bolt_protocol/message/begin_message.ex
+++ b/lib/bolty/bolt_protocol/message/begin_message.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.BoltProtocol.Message.BeginMessage do

--- a/lib/bolty/bolt_protocol/message/commit_message.ex
+++ b/lib/bolty/bolt_protocol/message/commit_message.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.BoltProtocol.Message.CommitMessage do

--- a/lib/bolty/bolt_protocol/message/discard_message.ex
+++ b/lib/bolty/bolt_protocol/message/discard_message.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.BoltProtocol.Message.DiscardMessage do

--- a/lib/bolty/bolt_protocol/message/goodbye_message.ex
+++ b/lib/bolty/bolt_protocol/message/goodbye_message.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.BoltProtocol.Message.GoodbyeMessage do

--- a/lib/bolty/bolt_protocol/message/hello_message.ex
+++ b/lib/bolty/bolt_protocol/message/hello_message.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.BoltProtocol.Message.HelloMessage do

--- a/lib/bolty/bolt_protocol/message/logoff_message.ex
+++ b/lib/bolty/bolt_protocol/message/logoff_message.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.BoltProtocol.Message.LogoffMessage do

--- a/lib/bolty/bolt_protocol/message/logon_message.ex
+++ b/lib/bolty/bolt_protocol/message/logon_message.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.BoltProtocol.Message.LogonMessage do

--- a/lib/bolty/bolt_protocol/message/pull_message.ex
+++ b/lib/bolty/bolt_protocol/message/pull_message.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.BoltProtocol.Message.PullMessage do

--- a/lib/bolty/bolt_protocol/message/reset_message.ex
+++ b/lib/bolty/bolt_protocol/message/reset_message.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.BoltProtocol.Message.ResetMessage do

--- a/lib/bolty/bolt_protocol/message/rollback_message.ex
+++ b/lib/bolty/bolt_protocol/message/rollback_message.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.BoltProtocol.Message.RollbackMessage do

--- a/lib/bolty/bolt_protocol/message/run_message.ex
+++ b/lib/bolty/bolt_protocol/message/run_message.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.BoltProtocol.Message.RunMessage do

--- a/lib/bolty/bolt_protocol/message/shared/auth_helper.ex
+++ b/lib/bolty/bolt_protocol/message/shared/auth_helper.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.BoltProtocol.Message.Shared.AuthHelper do

--- a/lib/bolty/bolt_protocol/message_decoder.ex
+++ b/lib/bolty/bolt_protocol/message_decoder.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.BoltProtocol.MessageDecoder do

--- a/lib/bolty/bolt_protocol/message_encoder.ex
+++ b/lib/bolty/bolt_protocol/message_encoder.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.BoltProtocol.MessageEncoder do

--- a/lib/bolty/bolt_protocol/server_response.ex
+++ b/lib/bolty/bolt_protocol/server_response.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.BoltProtocol.ServerResponse do

--- a/lib/bolty/bolt_protocol/versions.ex
+++ b/lib/bolty/bolt_protocol/versions.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.BoltProtocol.Versions do

--- a/lib/bolty/client.ex
+++ b/lib/bolty/client.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.Client do

--- a/lib/bolty/connection.ex
+++ b/lib/bolty/connection.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.Connection do

--- a/lib/bolty/connection_info.ex
+++ b/lib/bolty/connection_info.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.ConnectionInfo do

--- a/lib/bolty/enumerable_response.ex
+++ b/lib/bolty/enumerable_response.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defimpl Enumerable, for: Bolty.Response do

--- a/lib/bolty/error.ex
+++ b/lib/bolty/error.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.Error do

--- a/lib/bolty/pack_stream.ex
+++ b/lib/bolty/pack_stream.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.PackStream do

--- a/lib/bolty/pack_stream/markers.ex
+++ b/lib/bolty/pack_stream/markers.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.PackStream.Markers do

--- a/lib/bolty/pack_stream/packer.ex
+++ b/lib/bolty/pack_stream/packer.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defprotocol Bolty.PackStream.Packer do

--- a/lib/bolty/pack_stream/unpacker.ex
+++ b/lib/bolty/pack_stream/unpacker.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.PackStream.Unpacker do

--- a/lib/bolty/policy.ex
+++ b/lib/bolty/policy.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.Policy do

--- a/lib/bolty/policy/resolver.ex
+++ b/lib/bolty/policy/resolver.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.Policy.Resolver do

--- a/lib/bolty/query.ex
+++ b/lib/bolty/query.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.Query do

--- a/lib/bolty/response.ex
+++ b/lib/bolty/response.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.Response do

--- a/lib/bolty/response_encoder.ex
+++ b/lib/bolty/response_encoder.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.ResponseEncoder do

--- a/lib/bolty/response_encoder/json.ex
+++ b/lib/bolty/response_encoder/json.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defprotocol Bolty.ResponseEncoder.Json do

--- a/lib/bolty/response_encoder/json/native.ex
+++ b/lib/bolty/response_encoder/json/native.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.ResponseEncoder.Json.Native do

--- a/lib/bolty/types.ex
+++ b/lib/bolty/types.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.Types do

--- a/lib/bolty/types_helper.ex
+++ b/lib/bolty/types_helper.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.TypesHelper do

--- a/lib/bolty/utils/converters.ex
+++ b/lib/bolty/utils/converters.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.Utils.Converters do

--- a/lib/bolty/utils/logger.ex
+++ b/lib/bolty/utils/logger.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.Utils.Logger do

--- a/lib/bolty/utils/statement_splitter.ex
+++ b/lib/bolty/utils/statement_splitter.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.Utils.StatementSplitter do

--- a/lib/mix/tasks/test.matrix.ex
+++ b/lib/mix/tasks/test.matrix.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Mix.Tasks.Test.Matrix do

--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.Mixfile do

--- a/test/bolty/bolt_protocol/message/begin_message_test.exs
+++ b/test/bolty/bolt_protocol/message/begin_message_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.BoltProtocol.Message.BeginMessageTest do

--- a/test/bolty/bolt_protocol/message/commit_message_test.exs
+++ b/test/bolty/bolt_protocol/message/commit_message_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.BoltProtocol.Message.CommitMessageTest do

--- a/test/bolty/bolt_protocol/message/goodbye_message_test.exs
+++ b/test/bolty/bolt_protocol/message/goodbye_message_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.BoltProtocol.Message.GoodbyeMessageTest do

--- a/test/bolty/bolt_protocol/message/logoff_message_test.exs
+++ b/test/bolty/bolt_protocol/message/logoff_message_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.BoltProtocol.Message.LogoffMessageTest do

--- a/test/bolty/bolt_protocol/message/reset_message_test.exs
+++ b/test/bolty/bolt_protocol/message/reset_message_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.BoltProtocol.Message.ResetMessageTest do

--- a/test/bolty/bolt_protocol/message_decoder_test.exs
+++ b/test/bolty/bolt_protocol/message_decoder_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.BoltProtocol.MessageDecoderTest do

--- a/test/bolty/bolt_protocol/message_encoder_test.exs
+++ b/test/bolty/bolt_protocol/message_encoder_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.BoltProtocol.Message.MessageEncoderTest do

--- a/test/bolty/bolt_protocol/versions_test.exs
+++ b/test/bolty/bolt_protocol/versions_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.BoltProtocol.VersionsTest do

--- a/test/bolty/client_config_test.exs
+++ b/test/bolty/client_config_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.ClientConfigTest do

--- a/test/bolty/client_handshake_test.exs
+++ b/test/bolty/client_handshake_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.ClientHandshakeTest do

--- a/test/bolty/client_test.exs
+++ b/test/bolty/client_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.ClientTest do

--- a/test/bolty/connection_recovery_test.exs
+++ b/test/bolty/connection_recovery_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.ConnectionRecoveryTest do

--- a/test/bolty/connection_reset_rescue_test.exs
+++ b/test/bolty/connection_reset_rescue_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.ConnectionResetRescueTest do

--- a/test/bolty/connection_test.exs
+++ b/test/bolty/connection_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.ConnectionTest do

--- a/test/bolty/error_test.exs
+++ b/test/bolty/error_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.ErrorTest do

--- a/test/bolty/pack_stream_datetime_tz_test.exs
+++ b/test/bolty/pack_stream_datetime_tz_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.PackStream.DatetimeTzTest do

--- a/test/bolty/pack_stream_property_test.exs
+++ b/test/bolty/pack_stream_property_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.PackStreamPropertyTest do

--- a/test/bolty/pack_stream_test.exs
+++ b/test/bolty/pack_stream_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.PackStreamTest do

--- a/test/bolty/policy/resolver_test.exs
+++ b/test/bolty/policy/resolver_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.Policy.ResolverTest do

--- a/test/bolty/response_encoder/json_implementations_test.exs
+++ b/test/bolty/response_encoder/json_implementations_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.JsonImplementationsTest do

--- a/test/bolty/response_encoder_test.exs
+++ b/test/bolty/response_encoder_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.ResponseEncoderTest do

--- a/test/bolty/telemetry_test.exs
+++ b/test/bolty/telemetry_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.TelemetryTest do

--- a/test/bolty/timeout_test.exs
+++ b/test/bolty/timeout_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.TimeoutTest do

--- a/test/bolty/tls_test.exs
+++ b/test/bolty/tls_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.TLSTest do

--- a/test/bolty/types_helper_test.exs
+++ b/test/bolty/types_helper_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.TypesHelperTest do

--- a/test/bolty/types_test.exs
+++ b/test/bolty/types_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.TypesTest do

--- a/test/bolty/utils/converters_test.exs
+++ b/test/bolty/utils/converters_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule ConvertersTest do

--- a/test/bolty/utils/logger_test.exs
+++ b/test/bolty/utils/logger_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.Utils.LoggerTest do

--- a/test/bolty/utils/statement_splitter_test.exs
+++ b/test/bolty/utils/statement_splitter_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.Utils.StatementSplitterTest do

--- a/test/bolty_test.exs
+++ b/test/bolty_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule BoltyTest do

--- a/test/large_param_set_test.exs
+++ b/test/large_param_set_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Large.Param.Set.Test do

--- a/test/large_result_set_test.exs
+++ b/test/large_result_set_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Large.Result.Set.Test do

--- a/test/mix/tasks/test_matrix_test.exs
+++ b/test/mix/tasks/test_matrix_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Mix.Tasks.Test.MatrixTest do

--- a/test/response_test.exs
+++ b/test/response_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule ResponseTest do

--- a/test/streaming_test.exs
+++ b/test/streaming_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule StreamingTest do

--- a/test/support/fixture.ex
+++ b/test/support/fixture.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.Test.Fixture do

--- a/test/support/mocks/sock_mock.ex
+++ b/test/support/mocks/sock_mock.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.Mocks.SockMock do

--- a/test/support/test_derivation_struct.ex
+++ b/test/support/test_derivation_struct.ex
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Bolty.TestDerivationStruct do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 alias Bolty.BoltProtocol.Versions

--- a/test/tls/Dockerfile
+++ b/test/tls/Dockerfile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 #
 # Neo4j 5.26 LTS with a baked-in bolt server certificate, used by the

--- a/test/tls/gen_certs.sh
+++ b/test/tls/gen_certs.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 #
 # Generates a throwaway local CA and a Neo4j bolt server certificate for the

--- a/test/transaction_test.exs
+++ b/test/transaction_test.exs
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 bolty contributors
+# SPDX-FileCopyrightText: 2025 bolty contributors
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Transaction.Test do

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2024 bolty contributors
+SPDX-FileCopyrightText: 2025 bolty contributors
 SPDX-License-Identifier: Apache-2.0
 -->
 
@@ -352,13 +352,13 @@ bolty is Apache License 2.0 and is [REUSE](https://reuse.software/)-compliant. T
 - **Licence**: Apache-2.0 throughout. bolty derives from `boltx` (Luis Sagastume) which derives from `bolt_sips` (Florin Patrascu), both Apache-2.0. Upstream attribution lives in `NOTICE`; per-file headers carry the collective `bolty contributors` claim on our own modifications. Relicensing away from Apache-2.0 is not on the table — we don't own the upstream code and the patent grant is load-bearing for a protocol driver.
 - **Per-file header template** (hash-comment languages — Elixir, YAML, shell, etc.):
   ```
-  # SPDX-FileCopyrightText: 2024 bolty contributors
+  # SPDX-FileCopyrightText: 2025 bolty contributors
   # SPDX-License-Identifier: Apache-2.0
   ```
   For Markdown use HTML-comment form so GitHub renders it as nothing:
   ```html
   <!--
-  SPDX-FileCopyrightText: 2024 bolty contributors
+  SPDX-FileCopyrightText: 2025 bolty contributors
   SPDX-License-Identifier: Apache-2.0
   -->
   ```


### PR DESCRIPTION
The copyright year was wrong: bolty didn't exist in 2024.

- diffo-dev/bolty repo created **2025-04-30**
- first bolty commit **2025-06**
- `bolty` rename / hex-publish early **2026**

The `2024` in `NOTICE` and in every SPDX header was a placeholder that never got corrected.

## Changes
- `NOTICE`: bolty entry → `Copyright 2025 Matt Beanland and contributors.` (also aligned to the upstream bolt_sips/boltx attribution style).
- All 104 in-file `SPDX-FileCopyrightText: 2024 bolty contributors` headers → `2025`.
- `REUSE.toml` (3 entries) → `2025`.
- Upstream years unchanged (bolt_sips 2016, boltx 2023).

Comments/metadata only — no code change. REUSE lint compliant; compiles and formats clean.