### PR TITLE
docs: add TLS connection examples to README and usage-rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,11 @@ Bolty.start_link(
 )
 ```
 
+Generating and installing the server's certificates is Neo4j-side configuration —
+see Neo4j's [SSL framework](https://neo4j.com/docs/operations-manual/current/security/ssl-framework/)
+docs. Neo4j Aura and other managed offerings present public-CA certificates, so
+`+s` needs no setup.
+
 > **Changed in 0.3.0:** `+s`/`+ssc` verification was previously inverted, and
 > `+s` did no server authentication. `+s` now verifies by default, and explicit
 > `:ssl_opts` are no longer silently overridden. Pin `0.2.1` if you depend on the

--- a/README.md
+++ b/README.md
@@ -163,6 +163,28 @@ Any `:ssl_opts` you pass are merged **over** these defaults, so you can override
 verification (e.g. `ssl_opts: [verify: :verify_none]` for local development) or
 point at a private CA (`ssl_opts: [cacertfile: "..."]`).
 
+```elixir
+# Default TLS: bolt+s / neo4j+s verify the server cert against the OS trust
+# store — works out of the box for Neo4j Aura and other public CAs.
+{:ok, conn} =
+  Bolty.start_link(
+    scheme: "neo4j+s",
+    hostname: "xxxx.databases.neo4j.io",
+    auth: [username: "neo4j", password: System.fetch_env!("NEO4J_PASSWORD")]
+  )
+
+# Self-signed / internal certificate: use +ssc (encrypted, no verification).
+Bolty.start_link(scheme: "bolt+ssc", hostname: "neo4j.internal", auth: [username: "neo4j", password: "..."])
+
+# Verify against your own private CA instead of the OS trust store.
+Bolty.start_link(
+  scheme: "bolt+s",
+  hostname: "neo4j.internal",
+  ssl_opts: [cacertfile: "/etc/ssl/my-ca.pem"],
+  auth: [username: "neo4j", password: "..."]
+)
+```
+
 > **Changed in 0.3.0:** `+s`/`+ssc` verification was previously inverted, and
 > `+s` did no server authentication. `+s` now verifies by default, and explicit
 > `:ssl_opts` are no longer silently overridden. Pin `0.2.1` if you depend on the

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -112,7 +112,7 @@ Canonical option names (what `Bolty.Client.Config.new/1` actually reads):
 | `neo4j+s`, `bolt+s` | on | `verify: :verify_peer` (full cert verification against the OS trust store) |
 | `neo4j+ssc`, `bolt+ssc` | on | `verify: :verify_none` (encrypted, but self-signed / trust-all) |
 
-Default scheme when nothing is specified is `bolt+s`.
+Default scheme when nothing is specified is `bolt+s`. Examples: public-CA/Aura → `Bolty.start_link(scheme: "neo4j+s", hostname: "xxxx.databases.neo4j.io", auth: [...])`; self-signed → `scheme: "bolt+ssc"`; private CA → `scheme: "bolt+s", ssl_opts: [cacertfile: "/etc/ssl/my-ca.pem"]`. User `:ssl_opts` merge over the scheme defaults.
 
 ## 6. Value mapping — Elixir ↔ Bolt/Neo4j
 


### PR DESCRIPTION
The URI-scheme/TLS behaviour was documented in a table + prose, but with no **runnable example**. Given 0.3.0 makes `bolt+s`/`neo4j+s` verify the server certificate by default (and the upgrade notes point self-signed users to `+ssc` and private-CA users to `ssl_opts`), a concrete example is worth having.

Adds `Bolty.start_link/1` TLS examples covering the three cases:
- **public CA / Aura** — `scheme: "neo4j+s"` (verifies against the OS trust store);
- **self-signed / internal** — `scheme: "bolt+ssc"` (encrypted, no verification);
- **private CA** — `scheme: "bolt+s", ssl_opts: [cacertfile: ...]`.

README gets the full block (it ships in the Hex package, so it lands in 0.3.0); usage-rules §5 gets a one-line inline version. Docs-only.